### PR TITLE
feat(helm): add Traefik ingress controller support alongside nginx

### DIFF
--- a/charts/openstad-headless/templates/admin/ingress.yaml
+++ b/charts/openstad-headless/templates/admin/ingress.yaml
@@ -9,13 +9,17 @@ kind: Ingress
 
 metadata:
 
-{{- if .Values.admin.ingress.annotations }}
   annotations:
     {{- if .Values.clusterIssuer.enabled }}
     cert-manager.io/cluster-issuer: {{ template "openstad.clusterIssuer.name" . }}
     {{- end }}
-{{ toYaml .Values.admin.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if eq (include "openstad.ingress.type" .) "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ include "openstad.traefik.middlewares.admin" . }}
+    {{- else }}
+    {{- with .Values.admin.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
 
   labels:
   {{- include "openstad.labels" . | nindent 4 }}
@@ -28,7 +32,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
-  ingressClassName: {{ .Values.admin.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.admin.ingress.ingressClassName | default (include "openstad.ingress.type" .) }}
   rules:
 {{- range $host := .Values.admin.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -254,10 +254,10 @@ spec:
             value: "{{ .Values.clusterIssuer.prodIssuerName }}"
 
           - name: KUBERNETES_INGRESS_CLASS_NAME
-            value: "{{ .Values.api.createdIngresses.className | default "" }}"
+            value: "{{ .Values.api.createdIngresses.className | default (include "openstad.ingress.type" .) }}"
 
           - name: KUBERNETES_INGRESS_DEFAULT_ANNOTATIONS
-            value: '{{ .Values.api.createdIngresses.annotations | default "{}" | toJson }}'
+            value: '{{ include "openstad.createdIngresses.annotations" . }}'
 
           - name: KUBERNETES_INGRESS_TLS_MANAGED_BY_OPENSTAD
             value: "{{ .Values.api.createdIngresses.tlsManagedByOpenstad }}"

--- a/charts/openstad-headless/templates/api/ingress.yaml
+++ b/charts/openstad-headless/templates/api/ingress.yaml
@@ -9,13 +9,17 @@ kind: Ingress
 
 metadata:
 
-{{- if .Values.api.ingress.annotations }}
   annotations:
     {{- if .Values.clusterIssuer.enabled }}
     cert-manager.io/cluster-issuer: {{ template "openstad.clusterIssuer.name" . }}
     {{- end }}
-{{ toYaml .Values.api.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if eq (include "openstad.ingress.type" .) "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ include "openstad.traefik.middlewares.api" . }}
+    {{- else }}
+    {{- with .Values.api.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
 
   labels:
   {{- include "openstad.labels" . | nindent 4 }}
@@ -28,7 +32,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
-  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.api.ingress.ingressClassName | default (include "openstad.ingress.type" .) }}
   rules:
 {{- range $host := .Values.api.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/openstad-headless/templates/auth/ingress.yaml
+++ b/charts/openstad-headless/templates/auth/ingress.yaml
@@ -9,14 +9,18 @@ kind: Ingress
 
 metadata:
 
-{{- if .Values.auth.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/x-forwarded-proto: https
     {{- if .Values.clusterIssuer.enabled }}
     cert-manager.io/cluster-issuer: {{ template "openstad.clusterIssuer.name" . }}
     {{- end }}
-{{ toYaml .Values.auth.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if eq (include "openstad.ingress.type" .) "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ include "openstad.traefik.middlewares.auth" . }}
+    {{- else }}
+    nginx.ingress.kubernetes.io/x-forwarded-proto: https
+    {{- with .Values.auth.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
 
   labels:
   {{- include "openstad.labels" . | nindent 4 }}
@@ -29,7 +33,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
-  ingressClassName: {{ .Values.auth.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.auth.ingress.ingressClassName | default (include "openstad.ingress.type" .) }}
   rules:
 {{- range $host := .Values.auth.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/openstad-headless/templates/cms/ingress.yaml
+++ b/charts/openstad-headless/templates/cms/ingress.yaml
@@ -9,13 +9,17 @@ kind: Ingress
 
 metadata:
 
-{{- if .Values.cms.ingress.annotations }}
   annotations:
     {{- if .Values.clusterIssuer.enabled }}
     cert-manager.io/cluster-issuer: {{ template "openstad.clusterIssuer.name" . }}
     {{- end }}
-{{ toYaml .Values.cms.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if eq (include "openstad.ingress.type" .) "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ include "openstad.traefik.middlewares.cms" . }}
+    {{- else }}
+    {{- with .Values.cms.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
 
   labels:
   {{- include "openstad.labels" . | nindent 4 }}
@@ -28,7 +32,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
-  ingressClassName: {{ .Values.cms.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.cms.ingress.ingressClassName | default (include "openstad.ingress.type" .) }}
   rules:
 {{- range $host := .Values.cms.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/openstad-headless/templates/image/ingress.yaml
+++ b/charts/openstad-headless/templates/image/ingress.yaml
@@ -9,13 +9,17 @@ kind: Ingress
 
 metadata:
 
-{{- if .Values.image.ingress.annotations }}
   annotations:
     {{- if .Values.clusterIssuer.enabled }}
     cert-manager.io/cluster-issuer: {{ template "openstad.clusterIssuer.name" . }}
     {{- end }}
-{{ toYaml .Values.image.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if eq (include "openstad.ingress.type" .) "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ include "openstad.traefik.middlewares.image" . }}
+    {{- else }}
+    {{- with .Values.image.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+    {{- end }}
 
   labels:
   {{- include "openstad.labels" . | nindent 4 }}
@@ -28,7 +32,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 
 spec:
-  ingressClassName: {{ .Values.image.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.image.ingress.ingressClassName | default (include "openstad.ingress.type" .) }}
   rules:
 {{- range $host := .Values.image.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/openstad-headless/templates/traefik-middlewares.yaml
+++ b/charts/openstad-headless/templates/traefik-middlewares.yaml
@@ -1,0 +1,66 @@
+{{- if eq (include "openstad.ingress.type" .) "traefik" -}}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "openstad.fullname" . }}-security-headers
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+spec:
+  headers:
+    customResponseHeaders:
+      X-Content-Type-Options: "nosniff"
+      X-Frame-Options: "SAMEORIGIN"
+      X-Xss-Protection: "1"
+      Referrer-Policy: "same-origin"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "openstad.fullname" . }}-security-headers-hsts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+spec:
+  headers:
+    stsSeconds: 31536000
+    stsIncludeSubdomains: true
+    stsPreload: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "openstad.fullname" . }}-security-headers-noindex
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+spec:
+  headers:
+    customResponseHeaders:
+      X-Robots-Tag: "noindex, nofollow"
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "openstad.fullname" . }}-body-size-limit
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+spec:
+  buffering:
+    maxRequestBodyBytes: 134217728
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "openstad.fullname" . }}-www-redirect
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstad.labels" . | nindent 4 }}
+spec:
+  redirectRegex:
+    regex: "^https?://www\\.(.*)"
+    replacement: "https://${1}"
+    permanent: true
+{{- end -}}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -1,3 +1,8 @@
+# Ingress controller type: "nginx" or "traefik"
+global:
+  ingress:
+    type: nginx
+
 # Optional Dependencies
 
 disablePreInstallHelm: false
@@ -154,7 +159,7 @@ admin:
         more_set_headers "X-Robots-Tag: noindex, nofollow";
     extraLabels: {}
     hosts: []
-    ingressClassName: nginx
+    ingressClassName:  # defaults to global.ingress.type
     tls:
       secretName: openstad-tls-admin
       hosts: []
@@ -202,7 +207,7 @@ auth:
         more_set_headers "Referrer-Policy: same-origin";
     extraLabels: {}
     hosts: []
-    ingressClassName: nginx
+    ingressClassName:  # defaults to global.ingress.type
     tls:
       secretName: openstad-tls-auth
       hosts: []
@@ -260,12 +265,18 @@ api:
         more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
     extraLabels: {}
     hosts: []
-    ingressClassName: nginx
+    ingressClassName:  # defaults to global.ingress.type
     tls:
       secretName: openstad-tls-api
       hosts: []
   createdIngresses:
-    className:
+    className:  # defaults to global.ingress.type
+    # Annotations for dynamically created per-project ingresses.
+    # These are passed as a JSON env var to the API server.
+    # The defaults below are for nginx. When using global.ingress.type: traefik,
+    # override with traefik middleware annotations, e.g.:
+    #   annotations:
+    #     traefik.ingress.kubernetes.io/router.middlewares: "<namespace>-<release>-security-headers@kubernetescrd,<namespace>-<release>-security-headers-hsts@kubernetescrd,<namespace>-<release>-security-headers-noindex@kubernetescrd,<namespace>-<release>-body-size-limit@kubernetescrd,<namespace>-<release>-www-redirect@kubernetescrd"
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 128m
       nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -336,7 +347,7 @@ image:
         more_set_headers "Referrer-Policy: same-origin";
     extraLabels: {}
     hosts: []
-    ingressClassName: nginx
+    ingressClassName:  # defaults to global.ingress.type
     tls:
       secretName: openstad-tls-image
       hosts: []
@@ -404,7 +415,7 @@ cms:
         more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
     extraLabels: {}
     hosts: []
-    ingressClassName: nginx
+    ingressClassName:  # defaults to global.ingress.type
     tls:
       secretName: openstad-tls-cms
       hosts: []


### PR DESCRIPTION
Add global.ingress.type switch (nginx/traefik) to values.yaml that controls which ingress annotations and CRDs are rendered. When set to "traefik", five Middleware CRDs replace nginx-specific annotations for security headers, HSTS, noindex, body size limits, and www-redirect. All ingress templates and dynamic ingress env vars derive their configuration from the global type, maintaining full backward compatibility with existing nginx deployments.