### PR TITLE
test: close #1642 review gaps — enforce coverage gate, cover oauth2/votes/resources

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -103,9 +103,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --safe-chain-skip-minimum-package-age
 
-      - name: Run Vitest tests
-        run: npm run test:unit
-
+      # Runs the full unit-test suite AND enforces the coverage thresholds from
+      # the root vitest.config.ts; a failing threshold exits non-zero and blocks
+      # the build. No separate `test:unit` step — coverage runs the tests too.
       - name: Run Vitest tests with coverage
         run: npm run test:unit:coverage
 
@@ -114,9 +114,7 @@ jobs:
         if: always()
         with:
           name: coverage-reports
-          path: |
-            apps/api-server/coverage/
-            apps/auth-server/coverage/
+          path: coverage/
           retention-days: 7
 
   component-test:

--- a/apps/api-server/src/middleware/user.test.js
+++ b/apps/api-server/src/middleware/user.test.js
@@ -15,11 +15,26 @@ const JWT_SECRET = config.auth.jwtSecret;
 const originalUserFindOne = db.User.findOne;
 const originalProjectFindOne = db.Project.findOne;
 const originalAuthSettingsConfig = authSettings.config;
+const originalFixedAuthTokens = config.auth.fixedAuthTokens;
+
+// The `config` module forbids direct assignment to its properties at runtime
+// (immutable unless ALLOW_CONFIG_MUTATIONS is set), but the underlying property
+// is `configurable`, so Object.defineProperty can override it for a test.
+function setFixedAuthTokens(value) {
+  Object.defineProperty(config.auth, 'fixedAuthTokens', {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
 
 afterEach(() => {
   db.User.findOne = originalUserFindOne;
   db.Project.findOne = originalProjectFindOne;
   authSettings.config = originalAuthSettingsConfig;
+  // Restore fixedAuthTokens in case a test mutated the shared config singleton
+  setFixedAuthTokens(originalFixedAuthTokens);
 });
 
 function createMockReq(overrides = {}) {
@@ -122,6 +137,37 @@ describe('user middleware', () => {
       expect(next).toHaveBeenCalledWith();
     });
 
+    it('calls next with a TokenExpiredError on an expired JWT', async () => {
+      authSettings.config = vi.fn().mockResolvedValue({
+        provider: {},
+        adapter: 'openstad',
+        default: 'openstad',
+      });
+      // exp in the past => jsonwebtoken throws TokenExpiredError on verify
+      const token = jwt.sign(
+        {
+          userId: 10,
+          authProvider: 'openstad',
+          exp: Math.floor(Date.now() / 1000) - 60,
+        },
+        JWT_SECRET
+      );
+
+      const req = createMockReq({
+        headers: { authorization: `Bearer ${token}` },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await getUserMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      const error = next.mock.calls[0][0];
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('TokenExpiredError');
+      expect(req.user).toBeUndefined();
+    });
+
     it('calls next with error on invalid JWT', async () => {
       authSettings.config = vi.fn().mockResolvedValue({
         provider: {},
@@ -141,13 +187,21 @@ describe('user middleware', () => {
   });
 
   describe('fixed token', () => {
-    it('resolves userId from fixedAuthTokens and attaches db user as superuser', async () => {
-      const fixedTokens = config.auth && config.auth.fixedAuthTokens;
-      if (!fixedTokens || !fixedTokens[0]) {
-        return; // No fixed tokens configured in this environment
-      }
+    // The source reads config.auth.fixedAuthTokens fresh on each call from the
+    // shared `config` singleton, so we inject a token by mutating it here and
+    // restore it in afterEach. The header is a raw token (no "Bearer " prefix),
+    // matching the fixed-token branch in parseAuthHeader.
+    it('resolves userId from fixedAuthTokens and promotes the db user to superuser', async () => {
+      setFixedAuthTokens([
+        { token: 'fixed-secret-token', userId: 42, authProvider: 'openstad' },
+      ]);
 
-      const fakeUser = { id: 42, role: 'admin', projectId: 1 };
+      // dbUser on config.admin.projectId (1) => promoted to superuser
+      const fakeUser = {
+        id: 42,
+        role: 'admin',
+        projectId: config.admin.projectId,
+      };
       authSettings.config = vi.fn().mockResolvedValue({
         provider: {},
         adapter: 'openstad',
@@ -156,15 +210,49 @@ describe('user middleware', () => {
       db.User.findOne = vi.fn().mockResolvedValue(fakeUser);
 
       const req = createMockReq({
-        headers: { authorization: fixedTokens[0].token },
+        headers: { authorization: 'fixed-secret-token' },
       });
       const res = createMockRes();
       const next = vi.fn();
 
       await getUserMiddleware(req, res, next);
 
-      expect(req.user).toBeDefined();
-      expect(next).toHaveBeenCalled();
+      // findOne is queried by the fixed token's userId only (isFixed bypasses project scoping)
+      expect(db.User.findOne).toHaveBeenCalledWith({ where: { id: 42 } });
+      expect(req.user).toBe(fakeUser);
+      expect(req.user.role).toBe('superuser');
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('keeps the db user role for a fixed token user scoped to a non-admin project', async () => {
+      setFixedAuthTokens([
+        { token: 'fixed-secret-token', userId: 77, authProvider: 'openstad' },
+      ]);
+
+      // projectId differs from config.admin.projectId => role is NOT promoted
+      const fakeUser = {
+        id: 77,
+        role: 'member',
+        projectId: config.admin.projectId + 1000,
+      };
+      authSettings.config = vi.fn().mockResolvedValue({
+        provider: {},
+        adapter: 'openstad',
+        default: 'openstad',
+      });
+      db.User.findOne = vi.fn().mockResolvedValue(fakeUser);
+
+      const req = createMockReq({
+        headers: { authorization: 'fixed-secret-token' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await getUserMiddleware(req, res, next);
+
+      expect(req.user).toBe(fakeUser);
+      expect(req.user.role).toBe('member');
+      expect(next).toHaveBeenCalledWith();
     });
   });
 });

--- a/apps/api-server/src/routes/api/resource.test.js
+++ b/apps/api-server/src/routes/api/resource.test.js
@@ -138,6 +138,27 @@ describe('GET /:id — view single resource', () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('id', 42);
   });
+
+  // NOTE: the source rejects view permission via auth.can('Resource','view'),
+  // which throws a bare Error (status 500). Ideally this should be a 4xx (401/403),
+  // but we assert current behavior here without changing the source.
+  it('rejects read when user lacks view permission', async () => {
+    const resource = makeResource();
+    // list/findOne pass, but the 'view' check fails
+    // auth.can('Resource', action) invokes the static as can(action, user)
+    db.Resource.can = vi
+      .fn()
+      .mockImplementation((action) => (action === 'view' ? false : true));
+    db.Resource.scope = vi.fn().mockReturnValue({
+      findOne: vi.fn().mockResolvedValue(resource),
+    });
+
+    const app = createApp({ project: makeProject(), user: makeUser() });
+    const res = await request(app).get('/1/42');
+
+    expect(res.status).not.toBe(200);
+    expect(res.body.error).toMatch(/cannot view/i);
+  });
 });
 
 // ----------------------------------------------------------------------------------------------------
@@ -194,6 +215,78 @@ describe('POST / — create resource guards', () => {
     expect(res.status).toBe(500);
     expect(res.body.error).toMatch(/image server/i);
   });
+
+  // NOTE: the source rejects create permission via auth.can('Resource','create'),
+  // which throws a bare Error (status 500). Ideally this should be a 4xx (401/403),
+  // but we assert current behavior here without changing the source.
+  it('rejects create when user lacks create permission', async () => {
+    process.env.IMAGE_APP_URL = 'https://images.allowed.com';
+    // auth.can('Resource', action) invokes the static as can(action, user)
+    db.Resource.can = vi
+      .fn()
+      .mockImplementation((action) => (action === 'create' ? false : true));
+    const createSpy = vi.fn();
+    db.Resource.create = createSpy;
+
+    const app = createApp({ project: makeProject(), user: makeUser() });
+    const res = await request(app).post('/1/').send({ title: 'New' });
+
+    expect(res.status).not.toBe(200);
+    expect(res.body.error).toMatch(/cannot create/i);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates a resource on the happy path and returns the authorized resource', async () => {
+    process.env.IMAGE_APP_URL = 'https://images.allowed.com';
+
+    const createdInstance = makeResource({ id: 99 });
+    const createSpy = vi.fn().mockResolvedValue(createdInstance);
+    // authorizeData returns the model with .create chained off it
+    db.Resource.authorizeData = vi.fn().mockReturnValue({ create: createSpy });
+
+    db.Resource.can = vi.fn().mockReturnValue(true);
+    db.Status.findAll = vi.fn().mockResolvedValue([]);
+    db.Tag.findAll = vi.fn().mockResolvedValue([]);
+
+    // findByPk (after create) then findOne (after tags/statuses refetch)
+    const refetched = makeResource({
+      id: 99,
+      getTags: vi.fn().mockResolvedValue([]),
+    });
+    db.Resource.scope = vi.fn().mockReturnValue({
+      findByPk: vi.fn().mockResolvedValue(createdInstance),
+      findOne: vi.fn().mockResolvedValue(refetched),
+    });
+
+    const app = createApp({ project: makeProject(), user: makeUser() });
+    const res = await request(app).post('/1/').send({ title: 'New Resource' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id', 99);
+
+    // authorizeData called with the create action, the user and the project
+    expect(db.Resource.authorizeData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'New Resource',
+        projectId: '1',
+        userId: 1,
+      }),
+      'create',
+      expect.objectContaining({ id: 1 }),
+      null,
+      expect.objectContaining({ id: 1 })
+    );
+    // create called with the assembled data payload
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'New Resource',
+        projectId: '1',
+        userId: 1,
+        widgetId: null,
+        isSpam: false,
+      })
+    );
+  });
 });
 
 // ----------------------------------------------------------------------------------------------------
@@ -227,6 +320,67 @@ describe('PUT /:id — update resource guards', () => {
 
     expect(res.status).toBe(401);
     expect(res.body.error).toMatch(/gesloten/i);
+  });
+
+  // NOTE: the source rejects update via resource.can('update') with a bare Error
+  // (status 500). Ideally this should be a 4xx (401/403), but we assert current
+  // behavior here without changing the source.
+  it('rejects update when resource.can("update") is false', async () => {
+    const updateSpy = vi.fn();
+    const resource = makeResource({
+      dataValues: { publishDate: '2026-01-01' },
+      can: vi.fn().mockReturnValue(false),
+      authorizeData: vi.fn().mockReturnValue({ update: updateSpy }),
+    });
+
+    db.Resource.can = vi.fn().mockReturnValue(true);
+    db.Resource.scope = vi.fn().mockReturnValue({
+      findOne: vi.fn().mockResolvedValue(resource),
+    });
+
+    const app = createApp({ project: makeProject(), user: makeUser() });
+    const res = await request(app).put('/1/42').send({ title: 'Updated' });
+
+    expect(res.status).not.toBe(200);
+    expect(res.body.error).toMatch(/cannot update/i);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('updates a resource on the happy path with the submitted data', async () => {
+    const updatedInstance = makeResource({
+      id: 42,
+      title: 'Updated',
+      auth: { canMutateStatus: vi.fn().mockReturnValue(false) },
+    });
+    const updateSpy = vi.fn().mockResolvedValue(updatedInstance);
+    const authorizeDataSpy = vi.fn().mockReturnValue({ update: updateSpy });
+
+    const resource = makeResource({
+      dataValues: { publishDate: '2026-01-01' },
+      can: vi.fn().mockReturnValue(true),
+      authorizeData: authorizeDataSpy,
+    });
+
+    db.Resource.can = vi.fn().mockReturnValue(true);
+    db.Resource.scope = vi.fn().mockReturnValue({
+      findOne: vi.fn().mockResolvedValue(resource),
+    });
+
+    const app = createApp({ project: makeProject(), user: makeUser() });
+    const res = await request(app).put('/1/42').send({ title: 'Updated' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('id', 42);
+
+    // authorizeData called with the update action
+    expect(authorizeDataSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Updated' }),
+      'update'
+    );
+    // update called with the submitted payload
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Updated' })
+    );
   });
 });
 

--- a/apps/api-server/src/routes/api/vote.test.js
+++ b/apps/api-server/src/routes/api/vote.test.js
@@ -281,16 +281,15 @@ describe('POST / — vote creation', () => {
   it('creates a new like vote and returns the result', async () => {
     const project = makeProject({
       voteType: 'likes',
-      requiredUserRole: 'anonymous',
+      requiredUserRole: 'member',
     });
 
-    const newVote = {
+    const createdRow = {
       id: 5,
       resourceId: 1,
       userId: 1,
       confirmed: false,
       opinion: 'yes',
-      toJSON: () => ({ id: 5, resourceId: 1 }),
     };
 
     const mockScope = {
@@ -300,8 +299,9 @@ describe('POST / — vote creation', () => {
 
     const resource = { id: 1, statuses: [] };
     db.Resource.findAll = vi.fn().mockResolvedValue([resource]);
-    db.Vote.findAll = vi.fn().mockResolvedValue([]);
-    db.Vote.create = vi.fn().mockResolvedValue(newVote);
+    // First findAll = anonymous-IP block (not hit for non-anon); final findAll = result payload
+    db.Vote.findAll = vi.fn().mockResolvedValue([createdRow]);
+    db.Vote.create = vi.fn().mockResolvedValue(createdRow);
 
     db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => {
       return fn({});
@@ -314,7 +314,383 @@ describe('POST / — vote creation', () => {
       .send([{ resourceId: 1, opinion: 'yes' }]);
 
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    // A create action must have been dispatched with the right payload
+    expect(db.Vote.create).toHaveBeenCalledTimes(1);
+    const [createArg] = db.Vote.create.mock.calls[0];
+    expect(createArg).toMatchObject({
+      resourceId: 1,
+      opinion: 'yes',
+      userId: 1,
+      confirmed: false,
+    });
+    // Response is the shaped payload from the final findAll
+    expect(res.body).toEqual([
+      {
+        id: 5,
+        resourceId: 1,
+        userId: 1,
+        confirmed: false,
+        opinion: 'yes',
+      },
+    ]);
+  });
+});
+
+// ----------------------------------------------------------------------------------------------------
+// POST /* — voteType 'count' min/max resources rules
+// ----------------------------------------------------------------------------------------------------
+
+describe('POST / — count min/max resources', () => {
+  function setupCount({ minResources, maxResources }, resourceIds) {
+    const project = makeProject({
+      voteType: 'count',
+      withExisting: 'replace',
+      minResources,
+      maxResources,
+    });
+
+    const mockScope = { findAll: vi.fn().mockResolvedValue([]) };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+
+    db.Resource.findAll = vi
+      .fn()
+      .mockResolvedValue(resourceIds.map((id) => ({ id, statuses: [] })));
+    db.Vote.findAll = vi.fn().mockResolvedValue([]);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    return project;
+  }
+
+  it('returns 400 when fewer resources than minResources are submitted', async () => {
+    const project = setupCount({ minResources: 2, maxResources: 5 }, [1]);
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }]);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/aantal resources/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when more resources than maxResources are submitted', async () => {
+    const project = setupCount({ minResources: 1, maxResources: 2 }, [1, 2, 3]);
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }, { resourceId: 2 }, { resourceId: 3 }]);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/aantal resources/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('creates count votes when within min/max bounds', async () => {
+    const project = setupCount({ minResources: 1, maxResources: 5 }, [1, 2]);
+    db.Vote.findAll = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 7, resourceId: 1, userId: 1, confirmed: false, opinion: null },
+      ]);
+
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }, { resourceId: 2 }]);
+
+    expect(res.status).toBe(200);
+    expect(db.Vote.create).toHaveBeenCalledTimes(2);
+    expect(db.Vote.create.mock.calls[0][0]).toMatchObject({
+      resourceId: 1,
+      userId: 1,
+    });
+  });
+});
+
+// ----------------------------------------------------------------------------------------------------
+// POST /* — voteType 'budgeting' min/max budget rules
+// ----------------------------------------------------------------------------------------------------
+
+describe('POST / — budgeting min/max budget', () => {
+  function setupBudgeting({ minBudget, maxBudget }, resources) {
+    const project = makeProject({
+      voteType: 'budgeting',
+      withExisting: 'replace',
+      minBudget,
+      maxBudget,
+    });
+
+    const mockScope = { findAll: vi.fn().mockResolvedValue([]) };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+
+    db.Resource.findAll = vi.fn().mockResolvedValue(resources);
+    db.Vote.findAll = vi.fn().mockResolvedValue([]);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    return project;
+  }
+
+  it('returns 400 when summed budget is below minBudget', async () => {
+    const project = setupBudgeting({ minBudget: 500, maxBudget: 1000 }, [
+      { id: 1, statuses: [], budget: 100 },
+    ]);
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }]);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/budget/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when summed budget exceeds maxBudget', async () => {
+    const project = setupBudgeting({ minBudget: 0, maxBudget: 1000 }, [
+      { id: 1, statuses: [], budget: 700 },
+      { id: 2, statuses: [], budget: 600 },
+    ]);
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }, { resourceId: 2 }]);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/budget/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('creates budgeting votes when summed budget is within bounds', async () => {
+    const project = setupBudgeting({ minBudget: 0, maxBudget: 1000 }, [
+      { id: 1, statuses: [], budget: 400 },
+      { id: 2, statuses: [], budget: 300 },
+    ]);
+    db.Vote.findAll = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 8, resourceId: 1, userId: 1, confirmed: false, opinion: null },
+      ]);
+
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }, { resourceId: 2 }]);
+
+    expect(res.status).toBe(200);
+    expect(db.Vote.create).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ----------------------------------------------------------------------------------------------------
+// POST /* — withExisting 'merge' duplicate-resource rejection
+// ----------------------------------------------------------------------------------------------------
+
+describe('POST / — merge duplicate rejection', () => {
+  it('returns 403 when a submitted resource was already voted on (merge)', async () => {
+    const project = makeProject({ voteType: 'count', withExisting: 'merge' });
+
+    const existingVote = {
+      id: 99,
+      resourceId: 1,
+      opinion: null,
+      toJSON: () => ({ id: 99, resourceId: 1, opinion: null }),
+    };
+
+    const mockScope = { findAll: vi.fn().mockResolvedValue([existingVote]) };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }]);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/gestemd/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('merges existing votes with new ones when resources differ', async () => {
+    const project = makeProject({
+      voteType: 'count',
+      withExisting: 'merge',
+      minResources: 1,
+      maxResources: 5,
+    });
+
+    const existingVote = {
+      id: 99,
+      resourceId: 2,
+      opinion: null,
+      toJSON: () => ({ id: 99, resourceId: 2, opinion: null }),
+    };
+
+    const mockScope = { findAll: vi.fn().mockResolvedValue([existingVote]) };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+
+    db.Resource.findAll = vi.fn().mockResolvedValue([
+      { id: 1, statuses: [] },
+      { id: 2, statuses: [] },
+    ]);
+    db.Vote.findAll = vi.fn().mockResolvedValue([]);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+    // count voteType also deletes existing votes after re-creating merged copies
+    db.Vote.destroy = vi.fn().mockResolvedValue(1);
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    const app = createApp({ project, user: makeUser() });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1 }]);
+
+    expect(res.status).toBe(200);
+    // new vote (resource 1) created + existing merged vote (resource 2) re-created
+    expect(db.Vote.create).toHaveBeenCalledTimes(2);
+    const createdResourceIds = db.Vote.create.mock.calls
+      .map((c) => c[0].resourceId)
+      .sort();
+    expect(createdResourceIds).toEqual([1, 2]);
+  });
+});
+
+// ----------------------------------------------------------------------------------------------------
+// POST /* — anonymous likes 5-minute IP duplicate block
+// ----------------------------------------------------------------------------------------------------
+
+describe('POST / — anonymous likes IP duplicate block', () => {
+  it('returns 403 when an anonymous IP already voted within 5 minutes', async () => {
+    const project = makeProject({
+      voteType: 'likes',
+      requiredUserRole: 'anonymous',
+    });
+
+    const mockScope = { findAll: vi.fn().mockResolvedValue([]) };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+
+    db.Resource.findAll = vi.fn().mockResolvedValue([{ id: 1, statuses: [] }]);
+    // The IP-block findAll returns a recent vote -> rejection
+    db.Vote.findAll = vi.fn().mockResolvedValue([{ id: 50 }]);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    const app = createApp({ project, user: makeUser('anonymous') });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1, opinion: 'yes' }]);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/gestemd/i);
+    expect(db.Vote.create).not.toHaveBeenCalled();
+    // the block query filters on the 5-minute window
+    const [{ where }] = db.Vote.findAll.mock.calls[0];
+    expect(where.resourceId).toBe(1);
+    expect(where.createdAt).toBeDefined();
+  });
+});
+
+// ----------------------------------------------------------------------------------------------------
+// POST /* — likes action switch (create / update / delete)
+// ----------------------------------------------------------------------------------------------------
+
+describe('POST / — likes action switch', () => {
+  function setupLikes(existingVotes) {
+    const project = makeProject({
+      voteType: 'likes',
+      requiredUserRole: 'member',
+    });
+
+    const mockScope = {
+      findAll: vi.fn().mockResolvedValue(existingVotes),
+    };
+    db.Vote.scope = vi.fn().mockReturnValue(mockScope);
+
+    db.Resource.findAll = vi.fn().mockResolvedValue([{ id: 1, statuses: [] }]);
+    db.Vote.findAll = vi.fn().mockResolvedValue([]);
+    db.Vote.create = vi.fn().mockResolvedValue({});
+    db.Vote.update = vi.fn().mockResolvedValue([1]);
+    db.Vote.destroy = vi.fn().mockResolvedValue(1);
+
+    db.sequelize.transaction = vi.fn().mockImplementation(async (fn) => fn({}));
+
+    return project;
+  }
+
+  it('deletes the existing like when the same opinion is re-submitted (toggle off)', async () => {
+    const existing = {
+      id: 70,
+      resourceId: 1,
+      opinion: 'yes',
+      toJSON: () => ({ id: 70, resourceId: 1, opinion: 'yes' }),
+    };
+    const project = setupLikes([existing]);
+    const app = createApp({ project, user: makeUser('member') });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1, opinion: 'yes' }]);
+
+    expect(res.status).toBe(200);
+    expect(db.Vote.destroy).toHaveBeenCalledTimes(1);
+    expect(db.Vote.destroy.mock.calls[0][0].where).toEqual({ id: 70 });
+    expect(db.Vote.create).not.toHaveBeenCalled();
+    expect(db.Vote.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the existing like when a different opinion is submitted', async () => {
+    const existing = {
+      id: 71,
+      resourceId: 1,
+      opinion: 'no',
+      toJSON: () => ({ id: 71, resourceId: 1, opinion: 'no' }),
+    };
+    const project = setupLikes([existing]);
+    const app = createApp({ project, user: makeUser('member') });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1, opinion: 'yes' }]);
+
+    expect(res.status).toBe(200);
+    expect(db.Vote.update).toHaveBeenCalledTimes(1);
+    const [updatePayload, updateOpts] = db.Vote.update.mock.calls[0];
+    expect(updatePayload.opinion).toBe('yes');
+    expect(updateOpts.where).toEqual({ id: 71 });
+    expect(db.Vote.destroy).not.toHaveBeenCalled();
+    expect(db.Vote.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a new like when no existing vote for the resource', async () => {
+    const project = setupLikes([]);
+    const app = createApp({ project, user: makeUser('member') });
+
+    const res = await request(app)
+      .post('/')
+      .send([{ resourceId: 1, opinion: 'yes' }]);
+
+    expect(res.status).toBe(200);
+    expect(db.Vote.create).toHaveBeenCalledTimes(1);
+    expect(db.Vote.create.mock.calls[0][0]).toMatchObject({
+      resourceId: 1,
+      opinion: 'yes',
+    });
+    expect(db.Vote.update).not.toHaveBeenCalled();
+    expect(db.Vote.destroy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api-server/vitest.config.ts
+++ b/apps/api-server/vitest.config.ts
@@ -8,27 +8,8 @@ export default defineConfig({
     env: {
       NODE_CONFIG_DIR: path.resolve(__dirname, 'config'),
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      reportsDirectory: './coverage',
-      // Scope to files that have corresponding test coverage
-      include: [
-        'src/middleware/user.js',
-        'src/middleware/project.js',
-        'src/lib/deadlock-retry.js',
-        'src/lib/sequelize-authorization/lib/hasRole.js',
-        'src/lib/sequelize-authorization/middleware/index.js',
-        'src/routes/api/vote.js',
-        'src/routes/api/pending-budget-vote.js',
-        'src/routes/api/resource.js',
-      ],
-      thresholds: {
-        lines: 50,
-        statements: 50,
-        branches: 45,
-        functions: 50,
-      },
-    },
+    // Coverage (include scope + thresholds) is configured once at the repo root
+    // (/vitest.config.ts). Vitest ignores per-project coverage config in projects
+    // mode, so defining it here would be dead, misleading config.
   },
 });

--- a/apps/auth-server/controllers/auth/local.test.js
+++ b/apps/auth-server/controllers/auth/local.test.js
@@ -1,0 +1,216 @@
+import { createRequire } from 'module';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// NOTE: the controller is a CommonJS module whose `require` calls are NOT
+// intercepted by vi.mock under Vite SSR externalization. Instead we require the
+// SAME singleton modules the controller uses (shared require cache) and replace
+// their methods/exports directly. This makes the controller call our fakes.
+const require = createRequire(import.meta.url);
+
+const passport = require('passport');
+const db = require('../../db');
+const clientAuth = require('../../utils/clientAuth');
+const auditLog = require('../../middleware/auditLog');
+
+// passport.authenticate(strategy, cb) -> middleware(req,res,next) running cb.
+let passportResult = { err: null, user: null };
+const authSpy = vi
+  .spyOn(passport, 'authenticate')
+  .mockImplementation(
+    (strategy, cb) => (req, res, next) =>
+      cb(passportResult.err, passportResult.user, null)
+  );
+
+const userCreate = vi.fn();
+const origUser = db.User;
+db.User = () => ({ create: userCreate });
+
+const initSpy = vi
+  .spyOn(clientAuth, 'initializeClientAuth')
+  .mockResolvedValue(undefined);
+const saveSpy = vi
+  .spyOn(clientAuth, 'saveSession')
+  .mockResolvedValue(undefined);
+const logSpy = vi.spyOn(auditLog, 'logAuthEvent').mockImplementation(() => {});
+
+const local = require('./local');
+
+afterAll(() => {
+  authSpy.mockRestore();
+  initSpy.mockRestore();
+  saveSpy.mockRestore();
+  logSpy.mockRestore();
+  db.User = origUser;
+});
+
+const makeRes = () => ({ redirect: vi.fn(), render: vi.fn() });
+const makeReq = (overrides = {}) => ({
+  client: {
+    clientId: 'client-123',
+    redirectUrl: 'https://default.example.com',
+    config: {},
+  },
+  query: {},
+  params: {},
+  body: {},
+  flash: vi.fn(),
+  brute: { resetKey: vi.fn() },
+  bruteKey: 'bk',
+  session: {},
+  logIn: (user, cb) => cb(null),
+  ...overrides,
+});
+
+beforeEach(() => {
+  passportResult = { err: null, user: null };
+  userCreate.mockReset();
+  authSpy.mockClear();
+  initSpy.mockClear();
+  saveSpy.mockClear();
+  logSpy.mockClear();
+});
+
+describe('local.postLogin - invalid credentials', () => {
+  it('redirects back to login with clientId and an error flash when no user', () => {
+    const req = makeReq({
+      query: { redirect_uri: 'https://app.example.com/cb' },
+    });
+    const res = makeRes();
+
+    local.postLogin(req, res, vi.fn());
+
+    expect(req.flash).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ msg: expect.any(String) })
+    );
+    expect(logSpy).toHaveBeenCalledWith(req, 'login_failed', expect.anything());
+    const target = res.redirect.mock.calls[0][0];
+    expect(target).toContain('clientId=client-123');
+    expect(target).toContain(encodeURIComponent('https://app.example.com/cb'));
+  });
+
+  it('uses the /admin login url on a privileged route failure', () => {
+    const req = makeReq({ params: { priviligedRoute: 'admin' } });
+    const res = makeRes();
+
+    local.postLogin(req, res, vi.fn());
+
+    expect(res.redirect.mock.calls[0][0]).toContain('/admin');
+  });
+
+  it('falls back to client.redirectUrl when no redirect_uri query is given', () => {
+    const req = makeReq();
+    const res = makeRes();
+
+    local.postLogin(req, res, vi.fn());
+
+    expect(res.redirect.mock.calls[0][0]).toContain(
+      'redirect_uri=https://default.example.com'
+    );
+  });
+});
+
+describe('local.postLogin - passport error', () => {
+  it('forwards passport errors to next()', () => {
+    passportResult = { err: new Error('strategy boom'), user: null };
+    const next = vi.fn();
+
+    local.postLogin(makeReq(), makeRes(), next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'strategy boom' })
+    );
+  });
+});
+
+describe('local.postLogin - success', () => {
+  it('initializes client auth and redirects to the authorize dialog', async () => {
+    const user = { id: 7, email: 'a@b.com' };
+    passportResult = { err: null, user };
+    const req = makeReq({
+      query: { redirect_uri: 'https://app.example.com/cb' },
+    });
+    const res = makeRes();
+
+    local.postLogin(req, res, vi.fn());
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalled());
+
+    expect(initSpy).toHaveBeenCalledWith(
+      req.session,
+      req.client,
+      user,
+      expect.objectContaining({ authType: 'Local', twoFactorValid: false })
+    );
+    expect(saveSpy).toHaveBeenCalled();
+    expect(req.brute.resetKey).toHaveBeenCalledWith('bk');
+    expect(logSpy).toHaveBeenCalledWith(req, 'login', expect.anything());
+    const target = res.redirect.mock.calls[0][0];
+    expect(target).toContain('/dialog/authorize');
+    expect(target).toContain('response_type=code');
+    expect(target).toContain('client_id=client-123');
+  });
+
+  it('errors when there is no redirect_uri and no default redirectUrl', async () => {
+    passportResult = { err: null, user: { id: 7 } };
+    const req = makeReq({
+      client: { clientId: 'c', redirectUrl: null, config: {} },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    local.postLogin(req, res, next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+});
+
+describe('local.postRegister', () => {
+  it('creates the user, logs the event and redirects to login', async () => {
+    userCreate.mockResolvedValue({ id: 42 });
+    const req = makeReq({
+      body: { name: 'Jane', email: 'j@x.com', password: 'secret' },
+    });
+    const res = makeRes();
+
+    local.postRegister(req, res, vi.fn());
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalled());
+
+    expect(userCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Jane', email: 'j@x.com' })
+    );
+    // password must be hashed, not stored in clear text
+    expect(userCreate.mock.calls[0][0].password).not.toBe('secret');
+    expect(logSpy).toHaveBeenCalledWith(
+      req,
+      'register',
+      expect.objectContaining({ userId: 42 })
+    );
+    expect(res.redirect.mock.calls[0][0]).toContain('clientId=client-123');
+  });
+
+  it('forwards create errors to next()', async () => {
+    const boom = new Error('db down');
+    userCreate.mockRejectedValue(boom);
+    const next = vi.fn();
+    const req = makeReq({ body: { name: 'x', email: 'e', password: 'p' } });
+
+    local.postRegister(req, makeRes(), next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalledWith(boom));
+  });
+});
+
+describe('local.index', () => {
+  it('redirects logged-in users to /account', () => {
+    const res = makeRes();
+    local.index({ user: { id: 1 } }, res);
+    expect(res.redirect).toHaveBeenCalledWith('/account');
+  });
+
+  it('redirects anonymous users to /login', () => {
+    const res = makeRes();
+    local.index({}, res);
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+});

--- a/apps/auth-server/controllers/auth/url.test.js
+++ b/apps/auth-server/controllers/auth/url.test.js
@@ -1,0 +1,320 @@
+import { createRequire } from 'module';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The controller is CommonJS and its `require` calls are not intercepted by
+// vi.mock under Vite SSR. We require the same singleton modules it uses and
+// replace their methods/exports directly so the controller calls our fakes.
+const require = createRequire(import.meta.url);
+
+const passport = require('passport');
+const db = require('../../db');
+const verificationService = require('../../services/verificationService');
+const authService = require('../../services/authService');
+const tokenUrl = require('../../services/tokenUrl');
+const clientAuth = require('../../utils/clientAuth');
+const auditLog = require('../../middleware/auditLog');
+
+let passportResult = { err: null, user: null };
+const authSpy = vi
+  .spyOn(passport, 'authenticate')
+  .mockImplementation(
+    (strategy, opts, cb) => (req, res, next) =>
+      cb(passportResult.err, passportResult.user, null)
+  );
+
+const sendVerification = vi
+  .spyOn(verificationService, 'sendVerification')
+  .mockResolvedValue(undefined);
+const validatePrivilegeUser = vi
+  .spyOn(authService, 'validatePrivilegeUser')
+  .mockResolvedValue(undefined);
+const logSuccessFullLogin = vi
+  .spyOn(authService, 'logSuccessFullLogin')
+  .mockResolvedValue(undefined);
+const getUrlSpy = vi
+  .spyOn(tokenUrl, 'getUrl')
+  .mockReturnValue('https://app/auth/url/authenticate?token=tok');
+const initSpy = vi
+  .spyOn(clientAuth, 'initializeClientAuth')
+  .mockResolvedValue(undefined);
+const saveSpy = vi
+  .spyOn(clientAuth, 'saveSession')
+  .mockResolvedValue(undefined);
+const logSpy = vi.spyOn(auditLog, 'logAuthEvent').mockImplementation(() => {});
+
+const userFindOne = vi.fn();
+const userCreate = vi.fn();
+const userRoleFindOne = vi.fn();
+const origUser = db.User;
+const origUserRole = db.UserRole;
+db.User = { findOne: userFindOne, create: userCreate };
+db.UserRole = { findOne: userRoleFindOne };
+
+const url = require('./url');
+
+afterAll(() => {
+  authSpy.mockRestore();
+  sendVerification.mockRestore();
+  validatePrivilegeUser.mockRestore();
+  logSuccessFullLogin.mockRestore();
+  getUrlSpy.mockRestore();
+  initSpy.mockRestore();
+  saveSpy.mockRestore();
+  logSpy.mockRestore();
+  db.User = origUser;
+  db.UserRole = origUserRole;
+});
+
+const makeRes = () => ({
+  redirect: vi.fn(),
+  render: vi.fn(),
+  setHeader: vi.fn(),
+});
+const makeReq = (overrides = {}) => ({
+  client: {
+    id: 5,
+    clientId: 'client-9',
+    redirectUrl: 'https://default.example.com',
+    config: {},
+  },
+  query: {},
+  params: {},
+  body: {},
+  flash: vi.fn(),
+  brute: { resetKey: vi.fn() },
+  bruteKey: 'bk',
+  session: {},
+  header: vi.fn(() => 'https://referer.example.com'),
+  logIn: (user, cb) => cb(null),
+  ...overrides,
+});
+
+beforeEach(() => {
+  passportResult = { err: null, user: null };
+  vi.clearAllMocks();
+  sendVerification.mockResolvedValue(undefined);
+  logSuccessFullLogin.mockResolvedValue(undefined);
+  getUrlSpy.mockReturnValue('https://app/auth/url/authenticate?token=tok');
+  initSpy.mockResolvedValue(undefined);
+  saveSpy.mockResolvedValue(undefined);
+  userRoleFindOne.mockResolvedValue(null);
+});
+
+// ---------------------------------------------------------------------------
+// postLogin -> handleSending : magic-login email send path
+// ---------------------------------------------------------------------------
+describe('url.postLogin (magic-login send path)', () => {
+  it('sends a verification email to an existing user and redirects to confirmation', async () => {
+    const user = { id: 1, email: 'exists@x.com' };
+    userFindOne.mockResolvedValue(user);
+    const req = makeReq({
+      body: { email: 'exists@x.com' },
+      query: { redirect_uri: 'https://app.x/cb' },
+    });
+    const res = makeRes();
+
+    await url.postLogin(req, res, vi.fn());
+
+    expect(sendVerification).toHaveBeenCalledWith(
+      user,
+      req.client,
+      expect.any(String)
+    );
+    expect(req.flash).toHaveBeenCalledWith(
+      'success',
+      expect.objectContaining({ msg: expect.stringContaining('exists@x.com') })
+    );
+    const target = res.redirect.mock.calls[0][0];
+    expect(target).toContain('/auth/url/confirmation');
+    expect(target).toContain('clientId=client-9');
+  });
+
+  it('creates a new user when none exists, then sends the email', async () => {
+    userFindOne.mockResolvedValue(null);
+    const created = { id: 2, email: 'new@x.com' };
+    userCreate.mockResolvedValue(created);
+    const req = makeReq({ body: { email: 'new@x.com' } });
+    const res = makeRes();
+
+    await url.postLogin(req, res, vi.fn());
+
+    expect(userCreate).toHaveBeenCalledWith({ email: 'new@x.com' });
+    expect(sendVerification).toHaveBeenCalledWith(
+      created,
+      req.client,
+      expect.anything()
+    );
+  });
+
+  it('refuses to create a user when canCreateNewUsers is false', async () => {
+    userFindOne.mockResolvedValue(null);
+    const req = makeReq({
+      body: { email: 'blocked@x.com' },
+      client: {
+        id: 5,
+        clientId: 'client-9',
+        redirectUrl: 'r',
+        config: { users: { canCreateNewUsers: false } },
+      },
+    });
+    const res = makeRes();
+
+    await url.postLogin(req, res, vi.fn());
+
+    expect(userCreate).not.toHaveBeenCalled();
+    expect(sendVerification).not.toHaveBeenCalled();
+    expect(req.flash).toHaveBeenCalledWith('error', expect.anything());
+    expect(res.redirect).toHaveBeenCalledWith('https://referer.example.com');
+  });
+
+  it('uses the privileged path (client.id===1): validates user, and on send failure redirects with priviligedRoute', async () => {
+    const privUser = { id: 9, email: 'admin@x.com' };
+    validatePrivilegeUser.mockResolvedValue(privUser);
+    sendVerification.mockRejectedValue(new Error('smtp down'));
+    userFindOne.mockResolvedValue(null);
+    userCreate.mockResolvedValue({ id: 9, email: 'admin@x.com' });
+    const req = makeReq({
+      body: { email: 'admin@x.com' },
+      client: { id: 1, clientId: '1', redirectUrl: 'r', config: {} },
+    });
+    const res = makeRes();
+
+    await url.postLogin(req, res, vi.fn());
+
+    expect(validatePrivilegeUser).toHaveBeenCalledWith('admin@x.com', 1);
+    const target = res.redirect.mock.calls[0][0];
+    expect(target).toContain('/auth/url/login');
+    expect(target).toContain('priviligedRoute=admin');
+  });
+
+  it('on send failure (non-privileged) flashes error and redirects to url login', async () => {
+    userFindOne.mockResolvedValue({ id: 3, email: 'e@x.com' });
+    sendVerification.mockRejectedValue(new Error('smtp down'));
+    const req = makeReq({ body: { email: 'e@x.com' } });
+    const res = makeRes();
+
+    await url.postLogin(req, res, vi.fn());
+
+    expect(req.flash).toHaveBeenCalledWith('error', expect.anything());
+    expect(res.redirect.mock.calls[0][0]).toContain('/auth/url/login');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postAuthenticate : consuming the magic-login token
+// ---------------------------------------------------------------------------
+describe('url.postAuthenticate (token consumption)', () => {
+  it('forwards passport errors to next()', () => {
+    passportResult = { err: new Error('strategy boom'), user: null };
+    const next = vi.fn();
+
+    url.postAuthenticate(
+      makeReq({ query: { redirect_uri: 'https://app.x/cb' } }),
+      makeRes(),
+      next
+    );
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'strategy boom' })
+    );
+  });
+
+  it('errors when neither redirect_uri nor client.redirectUrl is present', () => {
+    passportResult = { err: null, user: { id: 1 } };
+    const req = makeReq({
+      client: { clientId: 'c', redirectUrl: null, config: {} },
+    });
+    const next = vi.fn();
+
+    url.postAuthenticate(req, makeRes(), next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('redirects back to the login screen with an expired-token message when token is invalid (no user)', () => {
+    passportResult = { err: null, user: null };
+    const req = makeReq({ query: { redirect_uri: 'https://app.x/cb' } });
+    const res = makeRes();
+
+    url.postAuthenticate(req, res, vi.fn());
+
+    expect(logSpy).toHaveBeenCalledWith(req, 'login_failed', expect.anything());
+    expect(req.flash).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ msg: expect.any(String) })
+    );
+    expect(res.redirect.mock.calls[0][0]).toContain('/auth/url/login');
+  });
+
+  it('on a valid token logs the user in, upgrades anonymous role and redirects to authorize', async () => {
+    const user = { id: 11 };
+    passportResult = { err: null, user };
+    const roleUpdate = vi.fn().mockResolvedValue(undefined);
+    // anonymousRoleId default is 3; an anonymous role should be upgraded.
+    userRoleFindOne.mockResolvedValue({ roleId: 3, update: roleUpdate });
+    const req = makeReq({ query: { redirect_uri: 'https://app.x/cb' } });
+    const res = makeRes();
+
+    url.postAuthenticate(req, res, vi.fn());
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalled());
+
+    expect(initSpy).toHaveBeenCalledWith(
+      req.session,
+      req.client,
+      user,
+      expect.objectContaining({ authType: 'Url' })
+    );
+    expect(saveSpy).toHaveBeenCalled();
+    expect(logSuccessFullLogin).toHaveBeenCalledWith(req);
+    expect(req.brute.resetKey).toHaveBeenCalledWith('bk');
+    const target = res.redirect.mock.calls[0][0];
+    expect(target).toContain('/dialog/authorize');
+    expect(target).toContain('response_type=code');
+  });
+
+  it('still redirects to authorize even if the role-upgrade lookup fails', async () => {
+    const user = { id: 12 };
+    passportResult = { err: null, user };
+    userRoleFindOne.mockRejectedValue(new Error('db hiccup'));
+    const req = makeReq({ query: { redirect_uri: 'https://app.x/cb' } });
+    const res = makeRes();
+
+    url.postAuthenticate(req, res, vi.fn());
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalled());
+
+    expect(res.redirect.mock.calls[0][0]).toContain('/dialog/authorize');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postRegister : finishes registration then bounces to the token login url
+// ---------------------------------------------------------------------------
+describe('url.postRegister', () => {
+  it('updates the user and redirects to the generated token URL', async () => {
+    const updated = { id: 4 };
+    const user = { update: vi.fn().mockResolvedValue(updated) };
+    const req = makeReq({
+      body: { name: 'N', postcode: '1000AA', token: 'tok' },
+      user,
+    });
+    const res = makeRes();
+
+    url.postRegister(req, res, vi.fn());
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalled());
+
+    expect(user.update).toHaveBeenCalledWith({ name: 'N', postcode: '1000AA' });
+    expect(getUrlSpy).toHaveBeenCalledWith(updated, req.client, 'tok');
+    expect(res.redirect).toHaveBeenCalledWith(
+      'https://app/auth/url/authenticate?token=tok'
+    );
+  });
+
+  it('forwards update errors to next()', async () => {
+    const boom = new Error('update failed');
+    const user = { update: vi.fn().mockRejectedValue(boom) };
+    const next = vi.fn();
+
+    url.postRegister(makeReq({ body: {}, user }), makeRes(), next);
+    await vi.waitFor(() => expect(next).toHaveBeenCalledWith(boom));
+  });
+});

--- a/apps/auth-server/controllers/oauth/oauth2.js
+++ b/apps/auth-server/controllers/oauth/oauth2.js
@@ -32,18 +32,18 @@ const expiresIn = { expires_in: config.token.expiresIn };
  * duration, etc. as parsed by the application.  The application issues a code,
  * which is bound to these values, and will be exchanged for an access token.
  */
-server.grant(
-  oauth2orize.grant.code((client, redirectURI, user, ares, done) => {
-    const code = utils.createToken({
-      sub: user.id,
-      exp: config.codeToken.expiresIn,
-    });
-    memoryStorage.authorizationCodes
-      .save(code, client.id, redirectURI, user.id, client.scope)
-      .then(() => done(null, code))
-      .catch((err) => done(err));
-  })
-);
+exports.issueAuthorizationCode = (client, redirectURI, user, ares, done) => {
+  const code = utils.createToken({
+    sub: user.id,
+    exp: config.codeToken.expiresIn,
+  });
+  memoryStorage.authorizationCodes
+    .save(code, client.id, redirectURI, user.id, client.scope)
+    .then(() => done(null, code))
+    .catch((err) => done(err));
+};
+
+server.grant(oauth2orize.grant.code(exports.issueAuthorizationCode));
 
 /**
  * Grant implicit authorization.
@@ -53,20 +53,20 @@ server.grant(
  * duration, etc. as parsed by the application.  The application issues a token,
  * which is bound to these values.
  */
-server.grant(
-  oauth2orize.grant.token((client, user, ares, done) => {
-    const token = utils.createToken({
-      sub: user.id,
-      exp: config.token.expiresIn,
-    });
-    const expiration = config.token.calculateExpirationDate();
+exports.issueImplicitToken = (client, user, ares, done) => {
+  const token = utils.createToken({
+    sub: user.id,
+    exp: config.token.expiresIn,
+  });
+  const expiration = config.token.calculateExpirationDate();
 
-    memoryStorage.accessTokens
-      .save(token, expiration, user.id, client.id, client.scope)
-      .then(() => done(null, token, expiresIn))
-      .catch((err) => done(err));
-  })
-);
+  memoryStorage.accessTokens
+    .save(token, expiration, user.id, client.id, client.scope)
+    .then(() => done(null, token, expiresIn))
+    .catch((err) => done(err));
+};
+
+server.grant(oauth2orize.grant.token(exports.issueImplicitToken));
 
 /**
  * Exchange authorization codes for access tokens.
@@ -76,31 +76,29 @@ server.grant(
  * are validated, the application issues an access token on behalf of the user who
  * authorized the code.
  */
-server.exchange(
-  oauth2orize.exchange.code((client, code, redirectURI, done) => {
-    memoryStorage.authorizationCodes
-      .delete(code)
-      .then((authCode) =>
-        validate.authCode(code, authCode, client, redirectURI)
-      )
-      .then((authCode) => validate.generateTokens(authCode))
-      .then((tokens) => {
-        if (tokens.length === 1) {
-          return done(null, tokens[0], null, expiresIn);
-        }
-        if (tokens.length === 2) {
-          return done(null, tokens[0], tokens[1], expiresIn);
-        }
-        throw new Error('Error exchanging auth code for tokens');
-      })
-      .catch((err) => {
-        console.log(
-          `[${new Date().toISOString()}][oauth] auth code exchange failed: ${err?.message}`
-        );
-        done(null, false);
-      });
-  })
-);
+exports.exchangeAuthorizationCode = (client, code, redirectURI, done) => {
+  memoryStorage.authorizationCodes
+    .delete(code)
+    .then((authCode) => validate.authCode(code, authCode, client, redirectURI))
+    .then((authCode) => validate.generateTokens(authCode))
+    .then((tokens) => {
+      if (tokens.length === 1) {
+        return done(null, tokens[0], null, expiresIn);
+      }
+      if (tokens.length === 2) {
+        return done(null, tokens[0], tokens[1], expiresIn);
+      }
+      throw new Error('Error exchanging auth code for tokens');
+    })
+    .catch((err) => {
+      console.log(
+        `[${new Date().toISOString()}][oauth] auth code exchange failed: ${err?.message}`
+      );
+      done(null, false);
+    });
+};
+
+server.exchange(oauth2orize.exchange.code(exports.exchangeAuthorizationCode));
 
 /**
  * Exchange user id and password for access tokens.
@@ -109,28 +107,28 @@ server.exchange(
  * from the token request for verification. If these values are validated, the
  * application issues an access token on behalf of the user who authorized the code.
  */
-server.exchange(
-  oauth2orize.exchange.password((client, username, password, scope, done) => {
-    db.User.findOne({ where: { email: username } })
-      .then((user) => validate.user(user, password))
-      .then((user) =>
-        validate.generateTokens({ scope, userID: user.id, clientID: client.id })
-      )
-      .then((tokens) => {
-        if (tokens === false) {
-          return done(null, false);
-        }
-        if (tokens.length === 1) {
-          return done(null, tokens[0], null, expiresIn);
-        }
-        if (tokens.length === 2) {
-          return done(null, tokens[0], tokens[1], expiresIn);
-        }
-        throw new Error('Error exchanging password for tokens');
-      })
-      .catch(() => done(null, false));
-  })
-);
+exports.exchangePassword = (client, username, password, scope, done) => {
+  db.User.findOne({ where: { email: username } })
+    .then((user) => validate.user(user, password))
+    .then((user) =>
+      validate.generateTokens({ scope, userID: user.id, clientID: client.id })
+    )
+    .then((tokens) => {
+      if (tokens === false) {
+        return done(null, false);
+      }
+      if (tokens.length === 1) {
+        return done(null, tokens[0], null, expiresIn);
+      }
+      if (tokens.length === 2) {
+        return done(null, tokens[0], tokens[1], expiresIn);
+      }
+      throw new Error('Error exchanging password for tokens');
+    })
+    .catch(() => done(null, false));
+};
+
+server.exchange(oauth2orize.exchange.password(exports.exchangePassword));
 
 /**
  * Exchange the client id and password/secret for an access token.
@@ -139,20 +137,22 @@ server.exchange(
  * password/secret from the token request for verification. If these values are validated, the
  * application issues an access token on behalf of the client who authorized the code.
  */
-server.exchange(
-  oauth2orize.exchange.clientCredentials((client, scope, done) => {
-    const token = utils.createToken({
-      sub: client.id,
-      exp: config.token.expiresIn,
-    });
-    const expiration = config.token.calculateExpirationDate();
-    // Pass in a null for user id since there is no user when using this grant type
+exports.exchangeClientCredentials = (client, scope, done) => {
+  const token = utils.createToken({
+    sub: client.id,
+    exp: config.token.expiresIn,
+  });
+  const expiration = config.token.calculateExpirationDate();
+  // Pass in a null for user id since there is no user when using this grant type
 
-    memoryStorage.accessTokens
-      .save(token, expiration, null, client.id, scope)
-      .then(() => done(null, token, null, expiresIn))
-      .catch((err) => done(err));
-  })
+  memoryStorage.accessTokens
+    .save(token, expiration, null, client.id, scope)
+    .then(() => done(null, token, null, expiresIn))
+    .catch((err) => done(err));
+};
+
+server.exchange(
+  oauth2orize.exchange.clientCredentials(exports.exchangeClientCredentials)
 );
 
 /**
@@ -162,17 +162,19 @@ server.exchange(
  * request for verification.  If this value is validated, the application issues an access
  * token on behalf of the client who authorized the code
  */
+exports.exchangeRefreshToken = (client, refreshToken, scope, done) => {
+  memoryStorage.refreshTokens
+    .find(refreshToken)
+    .then((foundRefreshToken) =>
+      validate.refreshToken(foundRefreshToken, refreshToken, client)
+    )
+    .then((foundRefreshToken) => validate.generateToken(foundRefreshToken))
+    .then((token) => done(null, token, null, expiresIn))
+    .catch(() => done(null, false));
+};
+
 server.exchange(
-  oauth2orize.exchange.refreshToken((client, refreshToken, scope, done) => {
-    memoryStorage.refreshTokens
-      .find(refreshToken)
-      .then((foundRefreshToken) =>
-        validate.refreshToken(foundRefreshToken, refreshToken, client)
-      )
-      .then((foundRefreshToken) => validate.generateToken(foundRefreshToken))
-      .then((token) => done(null, token, null, expiresIn))
-      .catch(() => done(null, false));
-  })
+  oauth2orize.exchange.refreshToken(exports.exchangeRefreshToken)
 );
 
 /*
@@ -192,46 +194,48 @@ server.exchange(
  * authorization).  We accomplish that here by routing through `ensureLoggedIn()`
  * first, and rendering the `dialog` view.
  */
+exports.validateAuthorizationClient = (clientId, redirectURI, scope, done) => {
+  db.Client.findOne({ where: { clientId: clientId } })
+    .then((client) => {
+      if (client) {
+        client.scope = scope; // eslint-disable-line no-param-reassign
+      }
+
+      /**
+       * Check if redirectURI same host as registered
+       */
+      const allowedDomains = prefillAllowedDomains(
+        client.allowedDomains ? client.allowedDomains : []
+      );
+      const redirectUrlHost = new URL(redirectURI).host;
+
+      //console.log('===> allowedDomains', allowedDomains, redirectUrlHost);
+
+      // throw error if allowedDomains is empty or the redirectURI's host is not present in the allowed domains
+      if (allowedDomains && allowedDomains.indexOf(redirectUrlHost) !== -1) {
+        // Find and encode returnTo param if present, this allows us to support returnTo urls with special characters (e.g. `?` and `&`)
+        const returnTo = redirectURI.substr(
+          redirectURI.lastIndexOf('returnTo=') + 9
+        );
+        if (returnTo) {
+          // encode returnTo param
+          const encodedReturnTo = encodeURIComponent(returnTo);
+          redirectURI = redirectURI.replace(returnTo, encodedReturnTo);
+        }
+        return done(null, client, redirectURI);
+      } else {
+        console.log(
+          `[${new Date().toISOString()}][oauth] redirect host not allowed: clientId=${client?.id} redirectHost=${redirectUrlHost}`
+        );
+        throw new Error("Redirect host doesn't match the client host");
+      }
+    })
+    .catch((err) => done(err));
+};
+
 exports.authorization = [
   login.ensureLoggedIn(),
-  server.authorization((clientId, redirectURI, scope, done) => {
-    db.Client.findOne({ where: { clientId: clientId } })
-      .then((client) => {
-        if (client) {
-          client.scope = scope; // eslint-disable-line no-param-reassign
-        }
-
-        /**
-         * Check if redirectURI same host as registered
-         */
-        const allowedDomains = prefillAllowedDomains(
-          client.allowedDomains ? client.allowedDomains : []
-        );
-        const redirectUrlHost = new URL(redirectURI).host;
-
-        //console.log('===> allowedDomains', allowedDomains, redirectUrlHost);
-
-        // throw error if allowedDomains is empty or the redirectURI's host is not present in the allowed domains
-        if (allowedDomains && allowedDomains.indexOf(redirectUrlHost) !== -1) {
-          // Find and encode returnTo param if present, this allows us to support returnTo urls with special characters (e.g. `?` and `&`)
-          const returnTo = redirectURI.substr(
-            redirectURI.lastIndexOf('returnTo=') + 9
-          );
-          if (returnTo) {
-            // encode returnTo param
-            const encodedReturnTo = encodeURIComponent(returnTo);
-            redirectURI = redirectURI.replace(returnTo, encodedReturnTo);
-          }
-          return done(null, client, redirectURI);
-        } else {
-          console.log(
-            `[${new Date().toISOString()}][oauth] redirect host not allowed: clientId=${client?.id} redirectHost=${redirectUrlHost}`
-          );
-          throw new Error("Redirect host doesn't match the client host");
-        }
-      })
-      .catch((err) => done(err));
-  }),
+  server.authorization(exports.validateAuthorizationClient),
   (req, res, next) => {
     // Render the decision dialog if the client isn't a trusted client
     // TODO:  Make a mechanism so that if this isn't a trusted client, the user can record that

--- a/apps/auth-server/controllers/oauth/oauth2.test.js
+++ b/apps/auth-server/controllers/oauth/oauth2.test.js
@@ -1,5 +1,5 @@
 import { createRequire } from 'module';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const require = createRequire(import.meta.url);
 // Import the REAL implementation used by oauth2.js (extracted to a dependency-free module)
@@ -9,15 +9,35 @@ const {
   prefillAllowedDomains,
 } = require('./allowed-domains');
 
-// The grant/exchange callbacks in oauth2.js are closures passed into oauth2orize
-// and are NOT exported, so they cannot be invoked in isolation. They are, however,
-// thin wrappers that delegate every meaningful decision to these dependency-free,
-// DB-free helpers (real JWTs via the bundled certs, in-memory token stores). The
-// suites below exercise those exact code paths end-to-end.
+// The REAL oauth2 controller. Importing it triggers oauth2orize grant/exchange
+// registration (harmless). Its grant/exchange/authorize callbacks are now named
+// exports, so the suites below invoke them directly with a mocked `done`.
+const oauth2 = require('./oauth2');
+
+// Real helpers/stores the controller delegates to (real JWT signing via bundled
+// certs, in-memory token stores). Only the Sequelize-backed model lookups are
+// mocked per test by reassigning methods on the shared db module instance.
 const utils = require('../../utils');
-const validate = require('../../validate');
 const memoryStorage = require('../../memoryStorage');
 const config = require('../../config');
+const db = require('../../db');
+
+// Promise-based callbacks: let the microtask/IO queue drain before asserting.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+// The access-token store persists via Sequelize (db.AccessToken.create). There is
+// no DB in unit tests, so stub the model method to resolve synchronously. This
+// keeps token-issuing promise chains deterministic (otherwise they depend on the
+// timing of a swallowed connection failure). Refresh/auth codes use the in-memory
+// stores and need no stubbing.
+let savedAccessTokenCreate;
+beforeEach(() => {
+  savedAccessTokenCreate = db.AccessToken.create;
+  db.AccessToken.create = vi.fn((attrs) => Promise.resolve(attrs));
+});
+afterEach(() => {
+  db.AccessToken.create = savedAccessTokenCreate;
+});
 
 // prefillAllowedDomains reads process.env at call time; isolate the env per test.
 const ENV_KEYS = ['BASE_DOMAIN', 'APP_URL', 'CMS_URL', 'API_URL', 'ADMIN_URL'];
@@ -143,84 +163,182 @@ describe('prefillAllowedDomains', () => {
   });
 });
 
+// Build a bcrypt-hashed password fixture once for the password-grant tests.
+const bcrypt = require('bcrypt');
+const VALID_PASSWORD = 's3cret';
+const VALID_HASH = bcrypt.hashSync(VALID_PASSWORD, 10);
+
 // ---------------------------------------------------------------------------
-// AUTHORIZE flow: redirectURI / host validation.
+// AUTHORIZE flow: oauth2.validateAuthorizationClient
 //
-// The authorize handler (oauth2.js `server.authorization` callback) computes
-// `prefillAllowedDomains(client.allowedDomains)` and accepts the request only if
-// `new URL(redirectURI).host` is a member of that set, otherwise it throws
-// "Redirect host doesn't match the client host". This is the security-critical
-// custom logic; we replicate the exact membership decision here.
+// Looks up the client, then accepts only when new URL(redirectURI).host is a
+// member of prefillAllowedDomains(client.allowedDomains); encodes a returnTo
+// query param when present; otherwise errors via done(err).
 // ---------------------------------------------------------------------------
-describe('authorize: redirectURI host validation', () => {
-  const isRedirectAllowed = (clientAllowedDomains, redirectURI) => {
-    const allowedDomains = prefillAllowedDomains(clientAllowedDomains || []);
-    const redirectUrlHost = new URL(redirectURI).host;
-    return allowedDomains && allowedDomains.indexOf(redirectUrlHost) !== -1;
+describe('validateAuthorizationClient (authorize)', () => {
+  let done;
+
+  beforeEach(() => {
+    done = vi.fn();
+  });
+
+  afterEach(() => {
+    delete db.Client.findOne;
+  });
+
+  const mockClient = (client) => {
+    db.Client.findOne = vi.fn().mockResolvedValue(client);
   };
 
-  it('accepts a redirectURI whose host matches a configured domain', () => {
-    expect(
-      isRedirectAllowed(
-        ['https://app.example.com'],
-        'https://app.example.com/callback?code=1'
-      )
-    ).toBe(true);
+  it('approves the client (err=null, returns client) when the redirect host is allowed', async () => {
+    const client = { id: 'c1', allowedDomains: ['https://app.example.com'] };
+    mockClient(client);
+
+    oauth2.validateAuthorizationClient(
+      'client-1',
+      'https://app.example.com/cb',
+      'openid',
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, returnedClient] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(returnedClient).toBe(client);
+    // scope is attached to the client.
+    expect(client.scope).toBe('openid');
   });
 
-  it('accepts a redirectURI on a parent of the configured domain', () => {
-    // prefillAllowedDomains adds parent domains, so example.com is allowed too.
-    expect(
-      isRedirectAllowed(['https://app.example.com'], 'https://example.com/cb')
-    ).toBe(true);
+  it('accepts a redirect on a parent domain of the configured host', async () => {
+    const client = { id: 'c1', allowedDomains: ['https://app.example.com'] };
+    mockClient(client);
+
+    oauth2.validateAuthorizationClient(
+      'client-1',
+      'https://example.com/cb',
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done.mock.calls[0][0]).toBeNull();
+    expect(done.mock.calls[0][1]).toBe(client);
   });
 
-  it('rejects a redirectURI host from an unrelated domain', () => {
-    expect(
-      isRedirectAllowed(
-        ['https://app.example.com'],
-        'https://evil.attacker.com/steal'
-      )
-    ).toBe(false);
+  it('url-encodes the returnTo param so special chars survive', async () => {
+    mockClient({ id: 'c1', allowedDomains: ['https://app.example.com'] });
+
+    const raw = 'https://app.example.com/cb?returnTo=/p?a=1&b=2';
+    oauth2.validateAuthorizationClient('client-1', raw, undefined, done);
+    await flush();
+
+    const redirectURI = done.mock.calls[0][2];
+    expect(redirectURI).toContain('returnTo=');
+    // The returnTo value is percent-encoded (the unencoded `?a=1&b=2` is gone).
+    expect(redirectURI).toContain(encodeURIComponent('/p?a=1&b=2'));
+    expect(redirectURI).not.toContain('returnTo=/p?a=1&b=2');
   });
 
-  it('rejects every redirectURI when the client has no allowed domains', () => {
-    expect(isRedirectAllowed([], 'https://app.example.com/cb')).toBe(false);
+  it('errors via done(err) when the redirect host is not allowed', async () => {
+    mockClient({ id: 'c1', allowedDomains: ['https://app.example.com'] });
+
+    oauth2.validateAuthorizationClient(
+      'client-1',
+      'https://evil.attacker.com/steal',
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, client] = done.mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/Redirect host doesn't match/);
+    expect(client).toBeUndefined();
   });
 
-  it('matches on host including port, not just hostname', () => {
-    expect(
-      isRedirectAllowed(['https://localhost:3000'], 'https://localhost:3000/cb')
-    ).toBe(true);
-    expect(
-      isRedirectAllowed(['https://localhost:3000'], 'https://localhost:4000/cb')
-    ).toBe(false);
+  it('errors when the client has no allowed domains', async () => {
+    mockClient({ id: 'c1', allowedDomains: [] });
+
+    oauth2.validateAuthorizationClient(
+      'client-1',
+      'https://app.example.com/cb',
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('forwards a db lookup rejection to done(err)', async () => {
+    db.Client.findOne = vi.fn().mockRejectedValue(new Error('db down'));
+
+    oauth2.validateAuthorizationClient(
+      'client-1',
+      'https://app.example.com/cb',
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(done.mock.calls[0][0].message).toBe('db down');
   });
 });
 
 // ---------------------------------------------------------------------------
-// EXCHANGE flow: authorization code -> access (+ optional refresh) tokens.
+// GRANT flow: oauth2.issueAuthorizationCode
 //
-// Mirrors oauth2.js `server.exchange(oauth2orize.exchange.code(...))`:
-//   authorizationCodes.delete(code)
-//     -> validate.authCode(code, authCode, client, redirectURI)
-//     -> validate.generateTokens(authCode)
-// using the real in-memory store, real JWT signing, and the real validators.
+// Issues a JWT code, persists it to the in-memory store bound to client/user,
+// then calls done(null, code).
 // ---------------------------------------------------------------------------
-describe('exchange: authorization code grant', () => {
+describe('issueAuthorizationCode (grant)', () => {
+  afterEach(async () => {
+    await memoryStorage.authorizationCodes.removeAll();
+  });
+
+  it('issues a verifiable code, persists it, and calls done(null, code)', async () => {
+    const done = vi.fn();
+    const client = { id: 'client-1', scope: 'openid' };
+    const user = { id: 'user-1' };
+
+    oauth2.issueAuthorizationCode(
+      client,
+      'https://app.example.com/cb',
+      user,
+      {},
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, code] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(code).sub).toBe('user-1');
+    // The code is retrievable from the store bound to the issuing client.
+    const stored = await memoryStorage.authorizationCodes.find(code);
+    expect(stored).toMatchObject({ clientID: 'client-1', userID: 'user-1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXCHANGE flow: oauth2.exchangeAuthorizationCode
+//
+// Consumes the stored code, validates it against the client, and issues an
+// access token (+ refresh token when scope is offline_access).
+// ---------------------------------------------------------------------------
+describe('exchangeAuthorizationCode (exchange)', () => {
   const client = { id: 'client-1' };
   const redirectURI = 'https://app.example.com/cb';
 
   afterEach(async () => {
     await memoryStorage.authorizationCodes.removeAll();
-    await memoryStorage.accessTokens.removeAll();
     await memoryStorage.refreshTokens.removeAll();
   });
 
-  const issueAuthCode = async ({
-    scope = undefined,
-    clientID = client.id,
-  } = {}) => {
+  const issueCode = async ({ scope, clientID = client.id } = {}) => {
     const code = utils.createToken({
       sub: 'user-1',
       exp: config.codeToken.expiresIn,
@@ -236,60 +354,136 @@ describe('exchange: authorization code grant', () => {
   };
 
   it('exchanges a valid code for a single access token (no offline scope)', async () => {
-    const code = await issueAuthCode();
+    const done = vi.fn();
+    const code = await issueCode();
 
-    const authCode = await memoryStorage.authorizationCodes.delete(code);
-    validate.authCode(code, authCode, client, redirectURI);
-    const tokens = await validate.generateTokens(authCode);
+    oauth2.exchangeAuthorizationCode(client, code, redirectURI, done);
+    await flush();
 
-    expect(tokens).toHaveLength(1);
-    // Issued token is a verifiable JWT for the authorizing user.
-    expect(utils.verifyToken(tokens[0]).sub).toBe('user-1');
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, accessToken, refreshToken] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(accessToken).sub).toBe('user-1');
+    expect(refreshToken).toBeNull();
   });
 
-  it('issues an access AND refresh token when scope is offline_access', async () => {
-    const code = await issueAuthCode({ scope: 'offline_access' });
+  it('issues access AND refresh tokens when scope is offline_access', async () => {
+    const done = vi.fn();
+    const code = await issueCode({ scope: 'offline_access' });
 
-    const authCode = await memoryStorage.authorizationCodes.delete(code);
-    validate.authCode(code, authCode, client, redirectURI);
-    const tokens = await validate.generateTokens(authCode);
+    oauth2.exchangeAuthorizationCode(client, code, redirectURI, done);
+    await flush();
 
-    expect(tokens).toHaveLength(2);
-    expect(utils.verifyToken(tokens[0])).toBeTruthy();
-    expect(utils.verifyToken(tokens[1])).toBeTruthy();
-    // The refresh token is persisted in the store for later exchange.
-    expect(await memoryStorage.refreshTokens.find(tokens[1])).toBeTruthy();
+    const [err, accessToken, refreshToken] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(accessToken)).toBeTruthy();
+    expect(utils.verifyToken(refreshToken)).toBeTruthy();
+    expect(await memoryStorage.refreshTokens.find(refreshToken)).toBeTruthy();
   });
 
-  it('rejects a code issued to a different client', async () => {
-    const code = await issueAuthCode({ clientID: 'someone-else' });
-    const authCode = await memoryStorage.authorizationCodes.delete(code);
+  it('calls done(null, false) for a code issued to a different client', async () => {
+    const done = vi.fn();
+    const code = await issueCode({ clientID: 'someone-else' });
 
-    expect(() =>
-      validate.authCode(code, authCode, client, redirectURI)
-    ).toThrow(/clientID does not match/);
+    oauth2.exchangeAuthorizationCode(client, code, redirectURI, done);
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
   });
 
-  it('consumes the code so it cannot be replayed', async () => {
-    const code = await issueAuthCode();
+  it('calls done(null, false) when the code was already consumed (replay)', async () => {
+    const done = vi.fn();
+    const code = await issueCode();
 
-    const first = await memoryStorage.authorizationCodes.delete(code);
-    expect(first).toBeTruthy();
-    // Second delete (replay) finds nothing.
-    const second = await memoryStorage.authorizationCodes.delete(code);
-    expect(second).toBeUndefined();
+    // First exchange consumes the code.
+    oauth2.exchangeAuthorizationCode(client, code, redirectURI, vi.fn());
+    await flush();
+
+    // Replay: the code no longer exists.
+    oauth2.exchangeAuthorizationCode(client, code, redirectURI, done);
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
   });
 });
 
 // ---------------------------------------------------------------------------
-// REFRESH flow: refresh token -> new access token.
+// EXCHANGE flow: oauth2.exchangePassword
 //
-// Mirrors oauth2.js `server.exchange(oauth2orize.exchange.refreshToken(...))`:
-//   refreshTokens.find(refreshToken)
-//     -> validate.refreshToken(found, refreshToken, client)
-//     -> validate.generateToken(found)
+// Looks up the user by email, verifies the bcrypt password, then issues tokens.
 // ---------------------------------------------------------------------------
-describe('exchange: refresh token grant', () => {
+describe('exchangePassword (exchange)', () => {
+  const client = { id: 'client-1' };
+
+  afterEach(async () => {
+    await memoryStorage.refreshTokens.removeAll();
+    delete db.User.findOne;
+  });
+
+  it('issues an access token for valid credentials', async () => {
+    db.User.findOne = vi
+      .fn()
+      .mockResolvedValue({ id: 'user-1', password: VALID_HASH });
+    const done = vi.fn();
+
+    oauth2.exchangePassword(
+      client,
+      'user@example.com',
+      VALID_PASSWORD,
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, accessToken, refreshToken] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(accessToken).sub).toBe('user-1');
+    expect(refreshToken).toBeNull();
+  });
+
+  it('calls done(null, false) for a wrong password', async () => {
+    db.User.findOne = vi
+      .fn()
+      .mockResolvedValue({ id: 'user-1', password: VALID_HASH });
+    const done = vi.fn();
+
+    oauth2.exchangePassword(
+      client,
+      'user@example.com',
+      'wrong-pass',
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
+  });
+
+  it('calls done(null, false) for an unknown user', async () => {
+    db.User.findOne = vi.fn().mockResolvedValue(null);
+    const done = vi.fn();
+
+    oauth2.exchangePassword(
+      client,
+      'nobody@example.com',
+      VALID_PASSWORD,
+      undefined,
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REFRESH flow: oauth2.exchangeRefreshToken
+//
+// Finds the stored refresh token, validates the owning client, then issues a
+// new access token.
+// ---------------------------------------------------------------------------
+describe('exchangeRefreshToken (exchange)', () => {
   const client = { id: 'client-1' };
 
   afterEach(async () => {
@@ -311,29 +505,79 @@ describe('exchange: refresh token grant', () => {
   };
 
   it('exchanges a valid refresh token for a new access token', async () => {
+    const done = vi.fn();
     const refreshToken = await issueRefreshToken();
 
-    const found = await memoryStorage.refreshTokens.find(refreshToken);
-    validate.refreshToken(found, refreshToken, client);
-    const accessToken = await validate.generateToken(found);
+    oauth2.exchangeRefreshToken(client, refreshToken, undefined, done);
+    await flush();
 
-    // A fresh, verifiable access-token JWT is issued for the authorizing user.
-    // (Persistence goes to the DB-backed access-token store, exercised in DB tests.)
-    expect(utils.verifyToken(accessToken).sub).toBe('user-1');
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, accessToken, returnedRefresh] = done.mock.calls[0];
+    expect(err).toBeNull();
+    // A fresh, verifiable access-token JWT is issued. Note: the source passes the
+    // raw token string (not the decoded record) to generateToken, so `sub` ends
+    // up empty rather than the user id - asserting issuance, not that quirk.
+    expect(utils.verifyToken(accessToken)).toBeTruthy();
+    expect(returnedRefresh).toBeNull();
   });
 
-  it('rejects a refresh token belonging to a different client', async () => {
+  it('calls done(null, false) for a refresh token of another client', async () => {
+    const done = vi.fn();
     const refreshToken = await issueRefreshToken({ clientID: 'other-client' });
-    const found = await memoryStorage.refreshTokens.find(refreshToken);
 
-    expect(() => validate.refreshToken(found, refreshToken, client)).toThrow(
-      /clientID does not match/
-    );
+    oauth2.exchangeRefreshToken(client, refreshToken, undefined, done);
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
   });
 
-  it('rejects a tampered / unverifiable refresh token', () => {
-    expect(() =>
-      validate.refreshToken({ clientID: client.id }, 'not-a-jwt', client)
-    ).toThrow();
+  it('calls done(null, false) for an unknown / tampered refresh token', async () => {
+    const done = vi.fn();
+
+    oauth2.exchangeRefreshToken(client, 'not-a-jwt', undefined, done);
+    await flush();
+
+    expect(done).toHaveBeenCalledWith(null, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GRANT flow: oauth2.issueImplicitToken
+// ---------------------------------------------------------------------------
+describe('issueImplicitToken (grant)', () => {
+  it('issues a verifiable access token and calls done(null, token, expiresIn)', async () => {
+    const done = vi.fn();
+
+    oauth2.issueImplicitToken(
+      { id: 'client-1', scope: 'openid' },
+      { id: 'user-1' },
+      {},
+      done
+    );
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, token, expiresIn] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(token).sub).toBe('user-1');
+    expect(expiresIn).toHaveProperty('expires_in');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXCHANGE flow: oauth2.exchangeClientCredentials
+// ---------------------------------------------------------------------------
+describe('exchangeClientCredentials (exchange)', () => {
+  it('issues a verifiable access token bound to the client', async () => {
+    const done = vi.fn();
+
+    oauth2.exchangeClientCredentials({ id: 'client-1' }, 'openid', done);
+    await flush();
+
+    expect(done).toHaveBeenCalledTimes(1);
+    const [err, token, refreshToken] = done.mock.calls[0];
+    expect(err).toBeNull();
+    expect(utils.verifyToken(token).sub).toBe('client-1');
+    expect(refreshToken).toBeNull();
   });
 });

--- a/apps/auth-server/controllers/oauth/oauth2.test.js
+++ b/apps/auth-server/controllers/oauth/oauth2.test.js
@@ -9,6 +9,16 @@ const {
   prefillAllowedDomains,
 } = require('./allowed-domains');
 
+// The grant/exchange callbacks in oauth2.js are closures passed into oauth2orize
+// and are NOT exported, so they cannot be invoked in isolation. They are, however,
+// thin wrappers that delegate every meaningful decision to these dependency-free,
+// DB-free helpers (real JWTs via the bundled certs, in-memory token stores). The
+// suites below exercise those exact code paths end-to-end.
+const utils = require('../../utils');
+const validate = require('../../validate');
+const memoryStorage = require('../../memoryStorage');
+const config = require('../../config');
+
 // prefillAllowedDomains reads process.env at call time; isolate the env per test.
 const ENV_KEYS = ['BASE_DOMAIN', 'APP_URL', 'CMS_URL', 'API_URL', 'ADMIN_URL'];
 let savedEnv;
@@ -130,5 +140,200 @@ describe('prefillAllowedDomains', () => {
     // All env vars are cleared in beforeEach
     const result = prefillAllowedDomains(['https://only.example.com']);
     expect(result).toContain('only.example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AUTHORIZE flow: redirectURI / host validation.
+//
+// The authorize handler (oauth2.js `server.authorization` callback) computes
+// `prefillAllowedDomains(client.allowedDomains)` and accepts the request only if
+// `new URL(redirectURI).host` is a member of that set, otherwise it throws
+// "Redirect host doesn't match the client host". This is the security-critical
+// custom logic; we replicate the exact membership decision here.
+// ---------------------------------------------------------------------------
+describe('authorize: redirectURI host validation', () => {
+  const isRedirectAllowed = (clientAllowedDomains, redirectURI) => {
+    const allowedDomains = prefillAllowedDomains(clientAllowedDomains || []);
+    const redirectUrlHost = new URL(redirectURI).host;
+    return allowedDomains && allowedDomains.indexOf(redirectUrlHost) !== -1;
+  };
+
+  it('accepts a redirectURI whose host matches a configured domain', () => {
+    expect(
+      isRedirectAllowed(
+        ['https://app.example.com'],
+        'https://app.example.com/callback?code=1'
+      )
+    ).toBe(true);
+  });
+
+  it('accepts a redirectURI on a parent of the configured domain', () => {
+    // prefillAllowedDomains adds parent domains, so example.com is allowed too.
+    expect(
+      isRedirectAllowed(['https://app.example.com'], 'https://example.com/cb')
+    ).toBe(true);
+  });
+
+  it('rejects a redirectURI host from an unrelated domain', () => {
+    expect(
+      isRedirectAllowed(
+        ['https://app.example.com'],
+        'https://evil.attacker.com/steal'
+      )
+    ).toBe(false);
+  });
+
+  it('rejects every redirectURI when the client has no allowed domains', () => {
+    expect(isRedirectAllowed([], 'https://app.example.com/cb')).toBe(false);
+  });
+
+  it('matches on host including port, not just hostname', () => {
+    expect(
+      isRedirectAllowed(['https://localhost:3000'], 'https://localhost:3000/cb')
+    ).toBe(true);
+    expect(
+      isRedirectAllowed(['https://localhost:3000'], 'https://localhost:4000/cb')
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EXCHANGE flow: authorization code -> access (+ optional refresh) tokens.
+//
+// Mirrors oauth2.js `server.exchange(oauth2orize.exchange.code(...))`:
+//   authorizationCodes.delete(code)
+//     -> validate.authCode(code, authCode, client, redirectURI)
+//     -> validate.generateTokens(authCode)
+// using the real in-memory store, real JWT signing, and the real validators.
+// ---------------------------------------------------------------------------
+describe('exchange: authorization code grant', () => {
+  const client = { id: 'client-1' };
+  const redirectURI = 'https://app.example.com/cb';
+
+  afterEach(async () => {
+    await memoryStorage.authorizationCodes.removeAll();
+    await memoryStorage.accessTokens.removeAll();
+    await memoryStorage.refreshTokens.removeAll();
+  });
+
+  const issueAuthCode = async ({
+    scope = undefined,
+    clientID = client.id,
+  } = {}) => {
+    const code = utils.createToken({
+      sub: 'user-1',
+      exp: config.codeToken.expiresIn,
+    });
+    await memoryStorage.authorizationCodes.save(
+      code,
+      clientID,
+      redirectURI,
+      'user-1',
+      scope
+    );
+    return code;
+  };
+
+  it('exchanges a valid code for a single access token (no offline scope)', async () => {
+    const code = await issueAuthCode();
+
+    const authCode = await memoryStorage.authorizationCodes.delete(code);
+    validate.authCode(code, authCode, client, redirectURI);
+    const tokens = await validate.generateTokens(authCode);
+
+    expect(tokens).toHaveLength(1);
+    // Issued token is a verifiable JWT for the authorizing user.
+    expect(utils.verifyToken(tokens[0]).sub).toBe('user-1');
+  });
+
+  it('issues an access AND refresh token when scope is offline_access', async () => {
+    const code = await issueAuthCode({ scope: 'offline_access' });
+
+    const authCode = await memoryStorage.authorizationCodes.delete(code);
+    validate.authCode(code, authCode, client, redirectURI);
+    const tokens = await validate.generateTokens(authCode);
+
+    expect(tokens).toHaveLength(2);
+    expect(utils.verifyToken(tokens[0])).toBeTruthy();
+    expect(utils.verifyToken(tokens[1])).toBeTruthy();
+    // The refresh token is persisted in the store for later exchange.
+    expect(await memoryStorage.refreshTokens.find(tokens[1])).toBeTruthy();
+  });
+
+  it('rejects a code issued to a different client', async () => {
+    const code = await issueAuthCode({ clientID: 'someone-else' });
+    const authCode = await memoryStorage.authorizationCodes.delete(code);
+
+    expect(() =>
+      validate.authCode(code, authCode, client, redirectURI)
+    ).toThrow(/clientID does not match/);
+  });
+
+  it('consumes the code so it cannot be replayed', async () => {
+    const code = await issueAuthCode();
+
+    const first = await memoryStorage.authorizationCodes.delete(code);
+    expect(first).toBeTruthy();
+    // Second delete (replay) finds nothing.
+    const second = await memoryStorage.authorizationCodes.delete(code);
+    expect(second).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REFRESH flow: refresh token -> new access token.
+//
+// Mirrors oauth2.js `server.exchange(oauth2orize.exchange.refreshToken(...))`:
+//   refreshTokens.find(refreshToken)
+//     -> validate.refreshToken(found, refreshToken, client)
+//     -> validate.generateToken(found)
+// ---------------------------------------------------------------------------
+describe('exchange: refresh token grant', () => {
+  const client = { id: 'client-1' };
+
+  afterEach(async () => {
+    await memoryStorage.refreshTokens.removeAll();
+  });
+
+  const issueRefreshToken = async ({ clientID = client.id } = {}) => {
+    const refreshToken = utils.createToken({
+      sub: 'user-1',
+      exp: config.refreshToken.expiresIn,
+    });
+    await memoryStorage.refreshTokens.save(
+      refreshToken,
+      'user-1',
+      clientID,
+      undefined
+    );
+    return refreshToken;
+  };
+
+  it('exchanges a valid refresh token for a new access token', async () => {
+    const refreshToken = await issueRefreshToken();
+
+    const found = await memoryStorage.refreshTokens.find(refreshToken);
+    validate.refreshToken(found, refreshToken, client);
+    const accessToken = await validate.generateToken(found);
+
+    // A fresh, verifiable access-token JWT is issued for the authorizing user.
+    // (Persistence goes to the DB-backed access-token store, exercised in DB tests.)
+    expect(utils.verifyToken(accessToken).sub).toBe('user-1');
+  });
+
+  it('rejects a refresh token belonging to a different client', async () => {
+    const refreshToken = await issueRefreshToken({ clientID: 'other-client' });
+    const found = await memoryStorage.refreshTokens.find(refreshToken);
+
+    expect(() => validate.refreshToken(found, refreshToken, client)).toThrow(
+      /clientID does not match/
+    );
+  });
+
+  it('rejects a tampered / unverifiable refresh token', () => {
+    expect(() =>
+      validate.refreshToken({ clientID: client.id }, 'not-a-jwt', client)
+    ).toThrow();
   });
 });

--- a/apps/auth-server/vitest.config.ts
+++ b/apps/auth-server/vitest.config.ts
@@ -4,10 +4,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['**/*.test.{js,ts}'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      reportsDirectory: './coverage',
-    },
+    // Coverage (include scope + thresholds) is configured once at the repo root
+    // (/vitest.config.ts). Vitest ignores per-project coverage config in projects
+    // mode, so defining it here would be dead, misleading config.
   },
 });

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -24,6 +24,35 @@ test:unit:cms
 test:unit:image
 ```
 
+#### Coverage
+
+Coverage is collected with the v8 provider and is configured **once at the repo
+root** in `vitest.config.ts`. Because Vitest ignores per-project `coverage`
+config in projects mode, the per-app config files do not define coverage.
+
+```bash
+npm run test:unit:coverage
+```
+
+This runs the full unit-test suite and enforces the coverage thresholds. The
+`coverage.include` list scopes measurement to the critical flows that have
+dedicated tests (auth middleware, OAuth2 domain allow-listing, votes, resource
+CRUD — see issue #1642); add a file there once it gains real coverage. The
+thresholds start at 20% lines (the baseline agreed in #1642) and should be
+ratcheted upwards as coverage grows.
+
+A failing threshold exits non-zero, which **blocks the CI build** — the
+`build-publish-docker` workflow runs `npm run test:unit:coverage` on every push
+and uploads the lcov report from `coverage/` as a build artifact.
+
+#### Critical-flow unit tests
+
+The api-server and auth-server have unit tests (vitest, DB mocked) for the most
+critical and most-changed flows: auth/token middleware, OAuth2 login (including
+the magic-login URL flow and domain allow-listing), votes (including budget and
+duplicate rules), and resource CRUD with permission checks. They run in a couple
+of seconds locally.
+
 ### Component Tests (Cypress)
 
 Component tests are written using Cypress. To run the component tests, use the following command from the root of the project:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,38 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     projects: ['apps/*', 'packages/*', 'packages/apostrophe-widgets/*'],
+    // Coverage MUST be configured at the workspace root: in Vitest projects mode
+    // per-project `coverage` blocks are ignored, so the thresholds below are the
+    // single source of truth that gates CI.
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      // Scope coverage to the critical flows that currently have dedicated tests
+      // (issue #1642). Add a file here once it gains real test coverage so the
+      // threshold reflects intentionally-tested code rather than the whole repo.
+      include: [
+        'apps/api-server/src/middleware/user.js',
+        'apps/api-server/src/middleware/project.js',
+        'apps/api-server/src/lib/deadlock-retry.js',
+        'apps/api-server/src/lib/sequelize-authorization/lib/hasRole.js',
+        'apps/api-server/src/lib/sequelize-authorization/middleware/index.js',
+        'apps/api-server/src/routes/api/vote.js',
+        'apps/api-server/src/routes/api/pending-budget-vote.js',
+        'apps/api-server/src/routes/api/resource.js',
+        'apps/auth-server/controllers/oauth/oauth2.js',
+        'apps/auth-server/controllers/oauth/allowed-domains.js',
+        'apps/auth-server/controllers/auth/local.js',
+        'apps/auth-server/controllers/auth/url.js',
+      ],
+      // Baseline gate per issue #1642 (start at 20% lines). A failing threshold
+      // fails `vitest run --coverage`, which blocks the CI build. Ratchet upwards
+      // as coverage improves.
+      thresholds: {
+        lines: 20,
+        statements: 20,
+        functions: 20,
+        branches: 20,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

Builds on `test/critical-flow-coverage` and resolves the gaps found while
reviewing it against the acceptance criteria of #1642. The base branch added the
test scaffolding; this PR makes the coverage gate actually enforce, fills the
missing critical-flow scenarios, and makes `oauth2.js` testable.

After this PR the full #1642 acceptance criteria are met.

## Why

Review of the base branch surfaced four real problems:

1. **The coverage gate never enforced.** Thresholds lived in the per-app
   `vitest.config.ts`, but Vitest ignores per-project `coverage` config in
   *projects* mode — CI passed at **0.9% line coverage**, exit 0.
2. **OAuth2 was effectively untested.** Only the extracted `allowed-domains`
   helper was covered; `authorize`/`exchange`/`refresh` and the `auth/local.js`
   + `auth/url.js` (magic-login) controllers had **zero** tests.
3. **Vote budget rules and resource create/update** — the core of the AC — were
   not exercised.
4. CI ran the suite twice; coverage artifact path was wrong.

## What changed

**Enforced coverage gate**
- Coverage config moved to the **root** `vitest.config.ts` (single source of
  truth), scoped via `include`, baseline **20% lines** per #1642. Verified: a
  too-high threshold now exits non-zero and blocks the build.
- Dead per-app coverage blocks removed and pointed at the root.
- CI: dropped the duplicate test run, runs only `test:unit:coverage`, fixed the
  artifact path to `coverage/`.

**OAuth2 made testable (behaviour-preserving refactor)**
- The oauth2orize grant/exchange/authorize callbacks were inline anonymous
  closures (0% coverage, untestable). Hoisted each to a **named module export**
  and passed the reference into oauth2orize — no behaviour change. Tests now hit
  the real allow-listing / token-exchange logic. `oauth2.js`: **0% → ~87%**.

**New / expanded tests**
- `auth/local.test.js` + `auth/url.test.js` (new): local login + magic-login URL
  flow.
- `oauth2.test.js`: authorize / exchange (auth-code, password, client-creds) /
  refresh against the real exports.
- `vote.test.js`: count & budgeting rules, merge + anonymous-IP duplicate
  detection, likes create/update/delete switch.
- `resource.test.js`: create/update happy paths + create/view/update permission
  denials.
- `user.test.js`: JWT expiry + a real (executing) fixed-token superuser test.
- `doc/testing.md`: coverage + critical-flow documentation.

## Verification

- `npm run test:unit` — **290 tests pass** (api + auth; +60 over the base).
- `npm run test:unit:coverage` — passes; gated coverage **72.2% lines**
  (oauth2.js 87%, vote.js 86%, middleware 100%).

## Known limitations / out of scope

- OAuth2 Express dialog/decision middleware and `deserializeClient` aren't
  unit-covered — they need a full HTTP/session round-trip (better as E2E).
- Two pre-existing `oauth2.js` quirks surfaced and asserted as *current*
  behaviour (not fixed here): a `redirectURI` without `returnTo` gets partially
  URL-encoded; refresh-grant access tokens get an empty `sub`. Worth a follow-up.
- `resource.js` permission denials throw a bare `Error` (HTTP 500) instead of a
  4xx; tests assert current behaviour with a note.

Refs #1642.
