### PR TITLE
feat(resource): normalize and validate extraData.url on create and update

### DIFF
--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -120,6 +120,34 @@ async function shouldSendUpdatedResourceAdminEmail(req) {
   }
 }
 
+function normalizeContributedUrl(value) {
+  if (typeof value !== 'string' || value.replace(/ /g, ' ').trim() === '') {
+    return { ok: true, value: value };
+  }
+
+  let normalized = value
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/ /g, ' ')
+    .trim();
+
+  if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
+    normalized = 'https://' + normalized;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return { ok: false };
+    }
+  } catch (_) {
+    return { ok: false };
+  }
+
+  return { ok: true, value: normalized };
+}
+
 // scopes: for all get requests
 router.all('*', function (req, res, next) {
   req.scope = [
@@ -486,6 +514,19 @@ router
       });
     }
 
+    if (data.extraData && typeof data.extraData.url !== 'undefined') {
+      const urlResult = normalizeContributedUrl(data.extraData.url);
+      if (!urlResult.ok) {
+        return next(
+          createError(
+            400,
+            'De ingevulde URL is ongeldig. Controleer of de link correct is en begin met https://'
+          )
+        );
+      }
+      data.extraData.url = urlResult.value;
+    }
+
     let responseData;
     db.Resource.authorizeData(data, 'create', req.user, null, req.project)
       .create(data)
@@ -776,6 +817,19 @@ router
 
     if (!userhasModeratorRights(req.user)) {
       delete data.modBreaks;
+    }
+
+    if (data.extraData && typeof data.extraData.url !== 'undefined') {
+      const urlResult = normalizeContributedUrl(data.extraData.url);
+      if (!urlResult.ok) {
+        return next(
+          createError(
+            400,
+            'De ingevulde URL is ongeldig. Controleer of de link correct is en begin met https://'
+          )
+        );
+      }
+      data.extraData.url = urlResult.value;
     }
 
     resource

--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -18,6 +18,7 @@ const {
   logSpamAnalysis,
   removeSpamMetaFields,
 } = require('../../services/spam-detector');
+const { normalizeContributedUrl } = require('../../util/normalize-url');
 
 const router = express.Router({ mergeParams: true });
 const userhasModeratorRights = (user) => {
@@ -118,34 +119,6 @@ async function shouldSendUpdatedResourceAdminEmail(req) {
     );
     return false;
   }
-}
-
-function normalizeContributedUrl(value) {
-  if (typeof value !== 'string' || value.replace(/ /g, ' ').trim() === '') {
-    return { ok: true, value: value };
-  }
-
-  let normalized = value
-    .replace(/[“”]/g, '"')
-    .replace(/[‘’]/g, "'")
-    .replace(/[–—]/g, '-')
-    .replace(/ /g, ' ')
-    .trim();
-
-  if (!normalized.startsWith('http://') && !normalized.startsWith('https://')) {
-    normalized = 'https://' + normalized;
-  }
-
-  try {
-    const parsed = new URL(normalized);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return { ok: false };
-    }
-  } catch (_) {
-    return { ok: false };
-  }
-
-  return { ok: true, value: normalized };
 }
 
 // scopes: for all get requests

--- a/apps/api-server/src/util/normalize-url.js
+++ b/apps/api-server/src/util/normalize-url.js
@@ -1,0 +1,39 @@
+// Normalizes user-contributed URLs. Programs like Word/Excel silently replace
+// straight quotes, hyphens and regular spaces with typographic variants; we map
+// those back before validating. Only http/https URLs are accepted.
+//
+// Returns { ok: true, value } with the normalized value, or { ok: false } when
+// the input is not a valid http/https URL.
+function normalizeContributedUrl(value) {
+  if (typeof value !== 'string' || value.replace(/ /g, ' ').trim() === '') {
+    return { ok: true, value: value };
+  }
+
+  let normalized = value
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/ /g, ' ')
+    .trim();
+
+  // Only prepend a scheme when none is present. A leading "scheme:" (e.g.
+  // http, https, mailto, ftp) is detected case-insensitively per RFC 3986, so
+  // "HTTP://..." is kept intact instead of being turned into "https://HTTP://...".
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(normalized);
+  if (!hasScheme) {
+    normalized = 'https://' + normalized;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return { ok: false };
+    }
+  } catch (_) {
+    return { ok: false };
+  }
+
+  return { ok: true, value: normalized };
+}
+
+module.exports = { normalizeContributedUrl };

--- a/apps/api-server/src/util/normalize-url.test.js
+++ b/apps/api-server/src/util/normalize-url.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+
+import normalizeUrl from './normalize-url.js';
+
+const { normalizeContributedUrl } = normalizeUrl;
+
+describe('normalizeContributedUrl', () => {
+  test('passes through non-string values unchanged', () => {
+    expect(normalizeContributedUrl(undefined)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+    expect(normalizeContributedUrl(null)).toEqual({ ok: true, value: null });
+  });
+
+  test('treats empty / whitespace-only input as valid and unchanged', () => {
+    expect(normalizeContributedUrl('')).toEqual({ ok: true, value: '' });
+    expect(normalizeContributedUrl('   ')).toEqual({ ok: true, value: '   ' });
+    // non-breaking space only
+    expect(normalizeContributedUrl(' ')).toEqual({
+      ok: true,
+      value: ' ',
+    });
+  });
+
+  test('replaces smart quotes with straight quotes', () => {
+    const result = normalizeContributedUrl('https://example.com/“path”');
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe('https://example.com/"path"');
+    expect(result.value).not.toMatch(/[“”]/);
+  });
+
+  test('replaces en/em dashes with a hyphen', () => {
+    const result = normalizeContributedUrl('https://example.com/a–b—c');
+    expect(result).toEqual({ ok: true, value: 'https://example.com/a-b-c' });
+  });
+
+  test('replaces non-breaking spaces with a regular space and trims', () => {
+    const result = normalizeContributedUrl(' https://example.com ');
+    expect(result).toEqual({ ok: true, value: 'https://example.com' });
+  });
+
+  test('prepends https:// when no scheme is present', () => {
+    expect(normalizeContributedUrl('www.example.com')).toEqual({
+      ok: true,
+      value: 'https://www.example.com',
+    });
+    expect(normalizeContributedUrl('example.com/path')).toEqual({
+      ok: true,
+      value: 'https://example.com/path',
+    });
+  });
+
+  test('keeps an existing http/https scheme intact', () => {
+    expect(normalizeContributedUrl('http://example.com')).toEqual({
+      ok: true,
+      value: 'http://example.com',
+    });
+    expect(normalizeContributedUrl('https://example.com/path')).toEqual({
+      ok: true,
+      value: 'https://example.com/path',
+    });
+  });
+
+  test('handles an uppercase scheme without mangling it', () => {
+    // Regression: a case-sensitive check used to turn "HTTP://" into
+    // "https://HTTP://..."; the scheme detection is now case-insensitive.
+    const result = normalizeContributedUrl('HTTP://example.com');
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe('HTTP://example.com');
+    expect(result.value).not.toContain('https://HTTP');
+  });
+
+  test('rejects non-http(s) schemes instead of silently mangling them', () => {
+    expect(normalizeContributedUrl('mailto:foo@bar.nl')).toEqual({ ok: false });
+    expect(normalizeContributedUrl('ftp://example.com')).toEqual({
+      ok: false,
+    });
+  });
+
+  test('rejects values that cannot be parsed as a URL', () => {
+    expect(normalizeContributedUrl('https://')).toEqual({ ok: false });
+  });
+});

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -126,8 +126,11 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
     NotificationService.addNotification('Inzending indienen gelukt', 'success');
   const notifySuccessEdit = () =>
     NotificationService.addNotification('Inzending bewerken gelukt', 'success');
-  const notifyFailed = () =>
-    NotificationService.addNotification('Inzending indienen mislukt', 'error');
+  const notifyFailed = (message?: string) =>
+    NotificationService.addNotification(
+      message || 'Inzending indienen mislukt',
+      'error'
+    );
   const notifyFailedEdit = (message: string) =>
     NotificationService.addNotification(message, 'error');
 
@@ -310,7 +313,7 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
       console.error(
         `[resource-form] create failed: widgetId=${props.widgetId} error=${e?.message}`
       );
-      notifyFailed();
+      notifyFailed(e?.message);
       setDisableSubmit(false);
     }
   }


### PR DESCRIPTION
Sanitizes user-contributed URLs (smart quotes, en/em-dashes, missing protocol) before saving. Returns a Dutch 400 error for values that are not valid http/https URLs. The resource-form widget propagates the API error message to the user via the notification toast.