### PR TITLE
test(auth-server): generate ephemeral JWT keys so oauth2 specs run in CI

### DIFF
--- a/apps/auth-server/test/setup.js
+++ b/apps/auth-server/test/setup.js
@@ -1,0 +1,21 @@
+// Vitest setup for the auth-server project.
+//
+// utils.js reads the JWT signing key at module-load time. The real `certs/`
+// directory is gitignored and is not generated in the unit-test CI job, so tests
+// that import the real utils/oauth code would otherwise fail with ENOENT.
+//
+// Instead of committing a key, we generate a throwaway RSA keypair in memory on
+// every test run and hand it to utils.js via the env vars it already prefers over
+// the on-disk certs (PRIVATE_KEY_BASE64 / PUBLIC_KEY_BASE64). Nothing is written
+// to disk or committed: each run (local and CI) gets a fresh test-only key that
+// signs/verifies JWTs and protects nothing real.
+const { generateKeyPairSync } = require('crypto');
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+process.env.PRIVATE_KEY_BASE64 = Buffer.from(privateKey).toString('base64');
+process.env.PUBLIC_KEY_BASE64 = Buffer.from(publicKey).toString('base64');

--- a/apps/auth-server/vitest.config.ts
+++ b/apps/auth-server/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['**/*.test.{js,ts}'],
+    // Runs before every test file: generates an ephemeral, test-only JWT
+    // keypair in memory so cert-dependent code loads without on-disk certs
+    // (see test/setup.js).
+    setupFiles: ['./test/setup.js'],
     // Coverage (include scope + thresholds) is configured once at the repo root
     // (/vitest.config.ts). Vitest ignores per-project coverage config in projects
     // mode, so defining it here would be dead, misleading config.


### PR DESCRIPTION
## What
Adds a Vitest setup file that, before every auth-server test run, generates a throwaway in-memory RSA keypair and exposes it via `PRIVATE_KEY_BASE64` / `PUBLIC_KEY_BASE64`.

- `apps/auth-server/test/setup.js` (new) — generates the ephemeral keypair in memory; nothing is written to disk or committed.
- `apps/auth-server/vitest.config.ts` — wires it via `setupFiles`.

## Why
`controllers/oauth/oauth2.test.js` imports the real `utils.js`, which reads the JWT key at **module load** (`PRIVATE_KEY_BASE64` env, else `fs.readFileSync('certs/privatekey.pem')`). The `certs/` dir is gitignored and only filled by `predev.sh` (on `npm run dev`), **not** in the unit-test CI job. That job runs plain `npm run test:unit` with no cert generation and no key env, so without this setup `oauth2.test.js` fails with **ENOENT** in CI.

## Scope / impact
- **Runtime/production: no impact** — this is test-only scaffolding (`setupFiles`), never runs in `node app.js`.
- **Tests in GitHub Actions: required** — the unit-test job is a bare checkout without certs; this is exactly where it's needed.
- Only `oauth2.test.js` imports `utils`; other auth-server tests are unaffected.

## Decision needed
This commit was previously removed from `test/critical-flow-coverage` so it could be reviewed properly instead of going in unreviewed. Alternatives if we don't want the ephemeral-key approach:
1. This PR (ephemeral keys in memory, nothing on disk).
2. Generate certs in the unit-test CI job (openssl step, like the E2E job already does).
3. Commit `test/test-certs/` + `TEST_CERTS=1` (least preferred — keys in the repo).

@rudivanhierden — is this needed, and is approach 1 OK?