### PR TITLE
fix(admin): persist displayLikes and largeDoc toggles on interactive image widget

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -46,6 +46,8 @@ const formSchema = z.object({
   hideCommentsList: z.boolean().optional(),
   hideFilters: z.boolean().optional(),
   hideToggleMarkers: z.boolean().optional(),
+  displayLikes: z.boolean().optional(),
+  largeDoc: z.boolean().optional(),
 });
 type FormData = z.infer<typeof formSchema>;
 
@@ -85,6 +87,8 @@ export default function DocumentGeneral(
       hideCommentsList: props?.hideCommentsList || false,
       hideFilters: props?.hideFilters || false,
       hideToggleMarkers: props?.hideToggleMarkers || false,
+      displayLikes: props?.displayLikes || false,
+      largeDoc: props?.largeDoc || false,
     },
   });
 


### PR DESCRIPTION
## Summary
- The documentmap (Interactieve afbeelding) widget's general tab was missing displayLikes and largeDoc in its useForm defaultValues
- This caused the YesNoSelect helper to reset both fields to false on every page load, silently discarding the saved DB value on next save
- Added both fields to defaultValues and formSchema, mirroring the sibling boolean fields

Related to openstad/openstad-headless#1572