### PR TITLE
fix(admin): allow tag filter toggle to be turned off in submission overview

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
@@ -28,24 +28,37 @@ import * as Switch from '@radix-ui/react-switch';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
 import * as z from 'zod';
 
-const formSchema = z.object({
-  displayTagFilters: z.boolean(),
-  tagGroups: z
-    .array(
+const formSchema = z
+  .object({
+    displayTagFilters: z.boolean(),
+    tagGroups: z.array(
       z.object({
         type: z.string(),
         label: z.string().optional(),
         multiple: z.boolean(),
       })
-    )
-    .refine((value) => value.some((item) => item), {
-      message: 'You have to select at least one item.',
-    }),
-  displayTagGroupName: z.boolean(),
-  filterBehavior: z.string().optional(),
-});
+    ),
+    displayTagGroupName: z.boolean(),
+    filterBehavior: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Only require at least one tag group when the tag filter is actually
+    // enabled; otherwise the toggle can be turned off / groups cleared freely.
+    if (
+      data.displayTagFilters === true &&
+      (!data.tagGroups || data.tagGroups.length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tagGroups'],
+        message:
+          "Selecteer minimaal één tag groep of schakel 'Filteren op tags weergeven' uit.",
+      });
+    }
+  });
 
 type Tag = {
   id: number;
@@ -72,6 +85,12 @@ export default function WidgetStemBegrootOverviewTags(
     props.updateConfig({ ...props, ...values });
   }
 
+  function onError() {
+    toast.error(
+      "Selecteer minimaal één tag groep of schakel 'Filteren op tags weergeven' uit."
+    );
+  }
+
   const form = useForm<FormData>({
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
@@ -88,7 +107,7 @@ export default function WidgetStemBegrootOverviewTags(
         <Heading size="xl">Tags</Heading>
         <Separator className="my-4" />
         <form
-          onSubmit={form.handleSubmit(onSubmit)}
+          onSubmit={form.handleSubmit(onSubmit, onError)}
           className="lg:w-3/3 grid grid-cols-1 gap-4">
           <FormField
             control={form.control}
@@ -291,6 +310,7 @@ export default function WidgetStemBegrootOverviewTags(
                     </>
                   ))}
                 </div>
+                <FormMessage />
               </FormItem>
             )}
           />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
@@ -33,13 +33,14 @@ import { ResourceOverviewWidgetProps } from '@openstad-headless/resource-overvie
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import toast from 'react-hot-toast';
 import * as z from 'zod';
 
-const formSchema = z.object({
-  displayTagFilters: z.boolean(),
-  showActiveTags: z.boolean().optional(),
-  tagGroups: z
-    .array(
+const formSchema = z
+  .object({
+    displayTagFilters: z.boolean(),
+    showActiveTags: z.boolean().optional(),
+    tagGroups: z.array(
       z.object({
         type: z.string(),
         label: z.string().optional(),
@@ -47,14 +48,26 @@ const formSchema = z.object({
         projectId: z.string().optional(),
         inlineOptions: z.boolean().optional(),
       })
-    )
-    .refine((value) => value.some((item) => item), {
-      message: 'You have to select at least one item.',
-    }),
-  displayTagGroupName: z.boolean(),
-  filterBehavior: z.string().optional(),
-  onlyShowTheseTagIds: z.string().optional(),
-});
+    ),
+    displayTagGroupName: z.boolean(),
+    filterBehavior: z.string().optional(),
+    onlyShowTheseTagIds: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Only require at least one tag group when the tag filter is actually
+    // enabled; otherwise the toggle can be turned off / groups cleared freely.
+    if (
+      data.displayTagFilters === true &&
+      (!data.tagGroups || data.tagGroups.length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tagGroups'],
+        message:
+          "Selecteer minimaal één tag groep of schakel 'Filteren op tags weergeven' uit.",
+      });
+    }
+  });
 
 type Tag = {
   id: number;
@@ -90,6 +103,12 @@ export default function WidgetResourceOverviewTags(
     props.updateConfig({ ...props, ...values });
   }
 
+  function onError() {
+    toast.error(
+      "Selecteer minimaal één tag groep of schakel 'Filteren op tags weergeven' uit."
+    );
+  }
+
   const form = useForm<FormData>({
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
@@ -108,7 +127,7 @@ export default function WidgetResourceOverviewTags(
         <Heading size="xl">Tags</Heading>
         <Separator className="my-4" />
         <form
-          onSubmit={form.handleSubmit(onSubmit)}
+          onSubmit={form.handleSubmit(onSubmit, onError)}
           className="lg:w-full grid grid-cols-1 gap-4">
           <FormField
             control={form.control}
@@ -360,6 +379,7 @@ export default function WidgetResourceOverviewTags(
                     </>
                   ))}
                 </div>
+                <FormMessage />
               </FormItem>
             )}
           />


### PR DESCRIPTION
## What
The "Filteren op tags weergeven?" toggle in the submission-overview Tags tab could be turned on but appeared stuck — it couldn't be turned off.

## Root cause
The Tags tab is a single react-hook-form form whose `tagGroups` field had a zod `.refine` requiring at least one tag group. Unchecking the last group made the entire tab's submit abort silently (no PUT, no toast), which looked like the toggle not responding.

## Fix
- Replace the field-level refine with an object-level `.superRefine` that only requires a tag group when `displayTagFilters` is enabled — so the toggle can be turned off and groups cleared freely.
- Add an inline `FormMessage` on the tag-groups field and an `onError` toast so a blocked save (filter enabled with zero groups) gives clear feedback.
- Same fix applied to the `resourceoverview` and `begrootmodule` Tags tabs.

Relates to openstad/openstad-headless#1578

## Scope
- admin
